### PR TITLE
fix: Hide markdown toolbar

### DIFF
--- a/src/frappe/userchrome.css
+++ b/src/frappe/userchrome.css
@@ -581,7 +581,7 @@ display: none !important;
 }
 
 /* Hide "Markdown/Richtext editor" Button */
-.tox-tbtn {
+.tox-toolbar {
 display: none !important;
 }
 

--- a/src/latte/userchrome.css
+++ b/src/latte/userchrome.css
@@ -614,7 +614,7 @@ div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
 }
 
 /* Hide "Markdown/Richtext editor" Button */
-.tox-tbtn {
+.tox-toolbar {
 display: none !important;
 }
 

--- a/src/macchiato/userchrome.css
+++ b/src/macchiato/userchrome.css
@@ -581,7 +581,7 @@ display: none !important;
 }
 
 /* Hide "Markdown/Richtext editor" Button */
-.tox-tbtn {
+.tox-toolbar {
 display: none !important;
 }
 

--- a/src/mocha/userchrome.css
+++ b/src/mocha/userchrome.css
@@ -581,7 +581,7 @@ display: none !important;
 }
 
 /* Hide "Markdown/Richtext editor" Button */
-.tox-tbtn {
+.tox-toolbar {
 display: none !important;
 }
 


### PR DESCRIPTION
Resolves issue #4 which blocks the top line of notes with an incomplete markdown toolbar