### PR TITLE
Remove gap in stacked view

### DIFF
--- a/src/frappe/userchrome.css
+++ b/src/frappe/userchrome.css
@@ -83,7 +83,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-	min-width: 200px !important;
 	background-color: var(--ctp-frappe-base) !important;
 }
 

--- a/src/latte/userchrome.css
+++ b/src/latte/userchrome.css
@@ -83,7 +83,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-  min-width: 200px !important;
   background-color: var(--ctp-latte-base) !important;
 }
 

--- a/src/macchiato/userchrome.css
+++ b/src/macchiato/userchrome.css
@@ -83,7 +83,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-	min-width: 200px !important;
 	background-color: var(--ctp-macchiato-base) !important;
 }
 

--- a/src/mocha/userchrome.css
+++ b/src/mocha/userchrome.css
@@ -83,7 +83,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-  min-width: 200px !important;
   background-color: var(--ctp-mocha-base) !important;
 }
 


### PR DESCRIPTION
Simple modification by removing one line in userchrome.css to delete gaps when you stack modules, as described in #11  