### PR TITLE
refactor: use whiskers

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,6 @@
+_default:
+  @just --list
+
+build:
+  whiskers templates/userchrome.tera
+  whiskers templates/userstyle.tera

--- a/src/frappe/userchrome.css
+++ b/src/frappe/userchrome.css
@@ -2,79 +2,53 @@
 /* For styling the entire Joplin app (except the rendered Markdown, which is defined in `userstyle.css`) */
 
 :root {
-	--ctp-frappe-rosewater: #f2d5cf;
-	--ctp-frappe-flamingo: #eebebe;
-	--ctp-frappe-pink: #f4b8e4;
-	--ctp-frappe-mauve: #ca9ee6;
-	--ctp-frappe-red: #e78284;
-	--ctp-frappe-maroon: #ea999c;
-	--ctp-frappe-peach: #ef9f76;
-	--ctp-frappe-yellow: #e5c890;
-	--ctp-frappe-green: #a6d189;
-	--ctp-frappe-teal: #81c8be;
-	--ctp-frappe-sky: #99d1db;
-	--ctp-frappe-sapphire: #85c1dc;
-	--ctp-frappe-blue: #8caaee;
-	--ctp-frappe-lavender: #babbf1;
-	--ctp-frappe-text: #c6ceef;
-	--ctp-frappe-subtext1: #b5bddc;
-	--ctp-frappe-subtext0: #a5acc9;
-	--ctp-frappe-overlay2: #949bb7;
-	--ctp-frappe-overlay1: #838aa4;
-	--ctp-frappe-overlay0: #737891;
-	--ctp-frappe-surface2: #62677e;
-	--ctp-frappe-surface1: #51566c;
-	--ctp-frappe-surface0: #414559;
-	--ctp-frappe-base: #303446;
-	--ctp-frappe-mantle: #292c3c;
-	--ctp-frappe-crust: #232634;
-	--font-face: "Noto Sans", Arial, Helvetica, sans-serif;
-	--font-mono: "Roboto Mono", Courier, monospace;
-	--font-size: 13px;
-	--icon-size: 16px;
+  --font-face: "Noto Sans", Arial, Helvetica, sans-serif;
+  --font-mono: "Roboto Mono", Courier, monospace;
+  --font-size: 13px;
+  --icon-size: 16px;
 
-	--regular: 400;
-	--bolder: 600;
+  --regular: 400;
+  --bolder: 600;
 
-	--scroll-radius: 3px;
+  --scroll-radius: 3px;
 
-	--opacity-0-8: 0.8;
+  --opacity-0-8: 0.8;
 }
 
 /* Font used by Joplin */
 * {
-	font-family: var(--font-face) !important;
+  font-family: var(--font-face) !important;
 }
 
 html, body {
-	background-color: var(--ctp-frappe-base) !important;
-	font-size: var(--font-size) !important;
-	font-weight: var(--regular) !important;
-	color: var(--light) !important;
+  background-color: #303446 !important;
+  font-size: var(--font-size) !important;
+  font-weight: var(--regular) !important;
+  color: var(--light) !important;
 }
 .CodeMirror-selected {
-		/* background-color: var(--lighter-grey) !important; */
-		background: #6B6B6B !important;
+    /* background-color: var(--lighter-grey) !important; */
+    background: #6B6B6B !important;
 }
 .rli-root {
-	background-color: var(--ctp-frappe-base) !important;
+  background-color: #303446 !important;
 }
 
 /* Icons */
 .fa, .far, .fas {
-	font-weight: 900 !important;
-	font-family: "Font Awesome 5 Free" !important;
-	font-size: var(--icon-size) !important;
+  font-weight: 900 !important;
+  font-family: "Font Awesome 5 Free" !important;
+  font-size: var(--icon-size) !important;
 }
 
 ::placeholder {
-	color: var(--ctp-frappe-lavender) !important;
+  color: #BABBF1 !important;
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar-thumb {
-	background-color: var(--ctp-frappe-surface0) !important;
-	border-radius: var(--scroll-radius) !important;
+  background-color: #414559 !important;
+  border-radius: var(--scroll-radius) !important;
 }
 
 /*********************************************************************************
@@ -83,8 +57,8 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-	min-width: 200px !important;
-	background-color: var(--ctp-frappe-base) !important;
+  min-width: 200px !important;
+  background-color: #303446 !important;
 }
 
 /*********************************************************************************
@@ -92,101 +66,101 @@ html, body {
 *********************************************************************************/
 
 .sidebar {
-	background-color: var(--ctp-frappe-crust) !important;
-	text-transform: uppercase;
-	font-weight: var(--bolder);
+  background-color: #232634 !important;
+  text-transform: uppercase;
+  font-weight: var(--bolder);
 }
 
 /* Hide "All notes" icon
  * Comment this next block if you want the "All notes" icon */
 i.icon-notes {
-	display: none !important;
+  display: none !important;
 }
 
 /* FOLDERS */
 
 /* "Add new notebook" button */
 .sidebar > div > div > button span {
-	color: var(--ctp-frappe-lavender) !important;
+  color: #BABBF1 !important;
 }
 
 .sidebar > div > div > button:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 .folders .list-item-container {
-		background-color: var(--ctp-frappe-crust) !important;
+    background-color: #232634 !important;
 }
 .folders .list-item-container:hover {
-	background-color: var(--ctp-frappe-overlay0) !important;
+  background-color: #737994 !important;
 }
 
 .folders .list-item-container a {
-	text-transform: initial;
-	color: var(--ctp-frappe-text) !important;
-	font-weight: var(--regular);
+  text-transform: initial;
+  color: #C6D0F5 !important;
+  font-weight: var(--regular);
 }
 
 .folders .list-item-container a:focus {
-	color: var(--ctp-frappe-text) !important;
-	background-color: var(--ctp-frappe-base) !important;
+  color: #C6D0F5 !important;
+  background-color: #303446 !important;
 }
 
 .folders .list-item-container a:hover {
-	color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 /* TAGS */
 .tags .list-item-container {
-		display: inline-block;
-		line-height: 0 !important;
-		padding: 0 !important;
-		height: auto !important;
-		background-color: var(--ctp-frappe-crust) !important;
+    display: inline-block;
+    line-height: 0 !important;
+    padding: 0 !important;
+    height: auto !important;
+    background-color: #232634 !important;
 }
 .tags .list-item-container:hover {
-	display: inline-block;
-	line-height: 0 !important;
-	padding: 0 !important;
-	height: auto !important;
-	background-color: var(--ctp-frappe-overlay0) !important;
+  display: inline-block;
+  line-height: 0 !important;
+  padding: 0 !important;
+  height: auto !important;
+  background-color: #737994 !important;
 }
 
 .tags .list-item-container a {
-	padding-left: 12px !important;
-	text-transform: initial;
-	color: var(--ctp-frappe-text) !important;
-	font-weight: var(--regular);
+  padding-left: 12px !important;
+  text-transform: initial;
+  color: #C6D0F5 !important;
+  font-weight: var(--regular);
 }
 
 .tags .list-item-container a:focus {
-	color: var(--ctp-frappe-text) !important;
-	background-color: var(--ctp-frappe-base) !important;
+  color: #C6D0F5 !important;
+  background-color: #303446 !important;
 }
 
 .tags .list-item-container a:hover {
-	color: var(--ctp-frappe-text) !important;
-	background-color: var(--ctp-frappe-overlay0) !important;
+  color: #C6D0F5 !important;
+  background-color: #737994 !important;
 }
 
 /* SYNCHRONIZATION */
 
 .sidebar > div:last-of-type {
-	background-color: none !important;
+  background-color: none !important;
 }
 
 .sidebar > div:last-of-type > button {
-	background-color: var(--ctp-frappe-lavender) !important;
-	border: 0px !important;
-	text-transform: uppercase;
-	font-size: var(--font-size) !important;
+  background-color: #BABBF1 !important;
+  border: 0px !important;
+  text-transform: uppercase;
+  font-size: var(--font-size) !important;
 }
 
 .sidebar > div:last-of-type > button:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 
 .sidebar > div:last-of-type > button > span {
-	color: var(--ctp-frappe-crust) !important;
+  color: #232634 !important;
 }
 
 /*********************************************************************************
@@ -194,111 +168,111 @@ i.icon-notes {
 *********************************************************************************/
 
 .note-list {
-	background-color: var(--ctp-frappe-mantle) !important;
-	border: none !important;
+  background-color: #292C3C !important;
+  border: none !important;
 }
 
 /* Empty notelist */
 .cLdGCO, .cLdGCO > div {
-	background-color: var(--ctp-frappe-mantle) !important;
+  background-color: #292C3C !important;
 }
 
 /* Remove border - introduced in 1.3.7 */
 .rli-noteList div {
-	border: none !important;
+  border: none !important;
 }
 
 /* BUTTONS SEARCH, SORT NOTES, NEW NOTE AND NEW TASK */
 
 div[height="50"] {
-	background-color: var(--ctp-frappe-mantle) !important;
+  background-color: #292C3C !important;
 }
 
 div[height="50"] input {
-	border: none !important;
-	color: var(--ctp-frappe-text) !important;
-	background-color: var(--ctp-frappe-mantle) !important;
+  border: none !important;
+  color: #C6D0F5 !important;
+  background-color: #292C3C !important;
 }
 
 div[height="50"] button {
-	background: transparent !important;
-	color: var(--ctp-frappe-text) !important;
-	border: 0 !important;
+  background: transparent !important;
+  color: #C6D0F5 !important;
+  border: 0 !important;
 }
 
 div[height="50"] button:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 
 div[height="50"] button span {
-	color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 .sc-hCPjZK.fJjcQe{
-	background-color: var(--ctp-frappe-mantle) !important;
+  background-color: #292C3C !important;
 }
 .new-note-todo-buttons > button {
-	background-color: var(--ctp-frappe-lavender) !important;
-	border: none !important;
+  background-color: #BABBF1 !important;
+  border: none !important;
 }
 .new-todo-button > span {
-	color: var(--ctp-frappe-crust) !important;
+  color: #232634 !important;
 }
 
 .search-bar {
-	background-color: var(--ctp-frappe-crust) !important;
+  background-color: #232634 !important;
 }
 
 .icon-search {
-	color: var(--ctp-frappe-lavender) !important;
+  color: #BABBF1 !important;
 }
 
 .sort-order-reverse-button {
-	background-color: var(--ctp-frappe-crust) !important;
+  background-color: #232634 !important;
 }
 .sort-order-reverse-button {
-	background-color: var(--ctp-frappe-crust) !important;
+  background-color: #232634 !important;
 }
 
 .fa-calendar-alt {
-	color: var(--ctp-frappe-lavender) !important;
+  color: #BABBF1 !important;
 }
 .fa-long-arrow-alt-up {
-	color: var(--ctp-frappe-lavender) !important;
+  color: #BABBF1 !important;
 }
 /* LIST OF NOTES */
 
 .note-list .list-item-container {
-	background-color: var(--ctp-frappe-mantle) !important;
+  background-color: #292C3C !important;
 }
 
 .note-list .list-item-container:hover {
-	background-color: var(--ctp-frappe-overlay1) !important;
+  background-color: #838BA7 !important;
 }
 
 .item-list.note-list .list-item-container::before {
-	border: none !important;
+  border: none !important;
 }
 
 .note-list .list-item-container a {
-	text-transform: initial;
-	color: var(--ctp-frappe-text) !important;
-	font-weight: var(--regular);
+  text-transform: initial;
+  color: #C6D0F5 !important;
+  font-weight: var(--regular);
 }
 
 .note-list .list-item-container a:focus {
-	color: var(--ctp-frappe-text) !important;
-	background-color: var(--ctp-frappe-base) !important;
+  color: #C6D0F5 !important;
+  background-color: #303446 !important;
 }
 
 .note-list .list-item-container a:hover {
-	color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 /* Add "..." to notes with long titles */
 .item-list.note-list .list-item-container > a > span {
-	overflow: hidden;
-	text-overflow: ellipsis;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /*********************************************************************************
@@ -310,21 +284,21 @@ div[height="50"] button span {
 /* Title */
 /* Changes frequently with updates, need to keep tabs */
 .rli-editor .cCOtNv > input {
-	padding-top: 5px;
-	background-color: var(--ctp-frappe-base) !important;
+  padding-top: 5px;
+  background-color: #303446 !important;
 }
 
 .title-input {
-  background-color: var(--ctp-frappe-base) !important;
-  color: var(--ctp-frappe-text) !important;
+  background-color: #303446 !important;
+  color: #C6D0F5 !important;
 }
 
 .editor-toolbar {
-	background-color: transparent !important;
+  background-color: transparent !important;
 }
 
 .editor-toolbar > div > a:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 
 /* Hide "Spell checker" button */
@@ -339,64 +313,64 @@ div[height="50"] button span {
 
 /* Hide the Toggle editors button */
 .editor-toolbar button[title="Toggle editors"] {
-	display: none !important;
+  display: none !important;
 }
 
 /* Breadcrumbs (In:...) - Used in tag listings */
 .cJOYJm {
-	background-color: var(--ctp-frappe-lavender) !important;
-	margin: 0px !important;
-	padding: 5px !important;
-	font-size: var(--font-size) !important;
+  background-color: #BABBF1 !important;
+  margin: 0px !important;
+  padding: 5px !important;
+  font-size: var(--font-size) !important;
 }
 
 .cJOYJm:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 
 /* CONTENT */
 /* Empty notebook */
 .rli-editor > div > div:empty {
-	background-color: var(--ctp-frappe-base) !important;
+  background-color: #303446 !important;
 }
 
 /* Editor layout splitter */
 .rli-editor > div > div > div > div > div > div > div:last-of-type {
-	border-color: var(--ctp-frappe-base) !important;
+  border-color: #303446 !important;
 }
 
 div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
-	background-color: var(--ctp-frappe-mantle) !important;
-	color: var(--ctp-frappe-text) !important;
+  background-color: #292C3C !important;
+  color: #C6D0F5 !important;
 }
 
 /* NOTE SEARCH BAR */
 .note-search-bar, .note-search-bar > div > div {
-	background-color: var(--ctp-frappe-base) !important;
-	width: 100%;
-	border: 0 !important;
+  background-color: #303446 !important;
+  width: 100%;
+  border: 0 !important;
 }
 
 .note-search-bar input {
-	border: 0 !important;
-	padding: 5px;
-	color: var(--ctp-frappe-text) !important;
-	background-color: var(--ctp-frappe-base) !important;
+  border: 0 !important;
+  padding: 5px;
+  color: #C6D0F5 !important;
+  background-color: #303446 !important;
 }
 
 /* TAGS */
 .tag-bar {
-	background-color: transparent !important;
+  background-color: transparent !important;
 }
 
 .tag-list > span {
-	color: var(--ctp-frappe-lavender) !important;
-	background-color: var(--ctp-frappe-crust) !important;
+  color: #BABBF1 !important;
+  background-color: #232634 !important;
 }
 
 /* Hide "Click to add tags..."*/
 a[Title="Tags"] + div > span {
-	display: none !important;
+  display: none !important;
 }
 
 /*********************************************************************************
@@ -404,128 +378,128 @@ a[Title="Tags"] + div > span {
 *********************************************************************************/
 
 .cm-s-material-darker.CodeMirror {
-	background-color: var(--ctp-frappe-base) !important;
-	color: var(--ctp-frappe-text) !important;
+  background-color: #303446 !important;
+  color: #C6D0F5 !important;
 }
 
 /* Header */
 .cm-header {
-	color: var(--ctp-frappe-lavender) !important;
+  color: #BABBF1 !important;
 }
 
 /* Italics/Emphasis, Bold, BoldItalics */
 .cm-em, .cm-strong, .cm-strong.cm-em {
-	color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 /* Lists (Bullet/number/todo) */
 .cm-variable-2, .cm-variable-3, .cm-keyword {
-	color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 .cm-s-material-darker .cm-variable-2.cm-rm-list-token {
-	color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 /* Links (link) */
 .cm-url {
-	color: var(--ctp-frappe-rosewater) !important;
-	opacity: 1;
-	text-decoration: underline;
+  color: #F2D5CF !important;
+  opacity: 1;
+  text-decoration: underline;
 }
 
 /* Links (text) */
 .cm-link-text {
-	color: var(--ctp-frappe-rosewater) !important;
+  color: #F2D5CF !important;
 }
 pre.CodeMirror-line {
-		color: var(--ctp-frappe-text) !important;
-		background-color: none !important;
+    color: #C6D0F5 !important;
+    background-color: none !important;
 }
 /* Image link in editor */
 span.cm-string.cm-url.cm-overlay.cm-rm-link.cm-overlay.cm-rm-image {
-	color: var(--ctp-frappe-lavender) !important;
+  color: #BABBF1 !important;
 }
 /* Comment outside code block */
 pre.CodeMirror-line span.cm-comment {
-	color: var(--ctp-frappe-overlay1) !important;
-	background-color: none !important;
-	border: 0 !important;
+  color: #838BA7 !important;
+  background-color: none !important;
+  border: 0 !important;
 }
 
 /* Codeblock selection colour */
 /* For some reason, the CodeMirror selection does not pick the colour correctly, left for now. */
 pre.CodeMirror-line span.CodeMirror-selectedtext {
-	/* background: var(--ctp-frappe-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #626880 !important; */
+  background: #6B6B6B !important;
 }
 
 div[class^="cm-jn-code-block-background "]::selection {
-	background-color: var(--ctp-frappe-base) !important;
-	border-color: var(--ctp-frappe-base) !important;
+  background-color: #303446 !important;
+  border-color: #303446 !important;
 }
 
 pre.cm-jn-code-block.CodeMirror-line span.cm-comment.cm-jn-monospace.CodeMirror-selectedtext {
-	/* background: var(--ctp-frappe-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #626880 !important; */
+  background: #6B6B6B !important;
 }
 pre.cm-jn-code-block.CodeMirror-line::selection {
-	/* background: var(--ctp-frappe-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #626880 !important; */
+  background: #6B6B6B !important;
 }
 div.cm-jn-code-block-background.CodeMirror-linebackground::selection {
-	/* background: var(--ctp-frappe-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #626880 !important; */
+  background: #6B6B6B !important;
 }
 pre.cm-jn-code-block.CodeMirror-line::selection span {
-	/* background: var(--ctp-frappe-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #626880 !important; */
+  background: #6B6B6B !important;
 }
 
 div.CodeMirror span.cm-comment.cm-jn-inline-code {
-	background-color: transparent !important;
-	padding-right: 0 !important;
-	padding-left: 0 !important;
+  background-color: transparent !important;
+  padding-right: 0 !important;
+  padding-left: 0 !important;
 }
 
 /* Code Block Text */
 div.CodeMirror span.cm-comment:not(.cm-jn-inline-code) {
-	color: var(--ctp-frappe-text) !important;
-	background-color: transparent !important;
+  color: #C6D0F5 !important;
+  background-color: transparent !important;
 }
 
 /* Code block background */
 div.CodeMirror div.cm-jn-code-block-background {
-		background-color: var(--ctp-frappe-mantle) !important;
+    background-color: #292C3C !important;
 }
 
 /* Horizontal Line */
 .cm-hr {
-	color: var(--ctp-frappe-overlay0) !important;
+  color: #737994 !important;
 }
 
 /* Cursor colour */
 .CodeMirror-cursor {
-		border-left: 1px solid var(--ctp-frappe-rosewater) !important;
-		border-right: none !important;
-		width: 0 !important;
+    border-left: 1px solid #F2D5CF !important;
+    border-right: none !important;
+    width: 0 !important;
 }
 .cm-fat-cursor div.CodeMirror-cursor {
-		width: 10px !important;
-		border: 0 !important;
-		background: var(--ctp-frappe-rosewater) !important;
+    width: 10px !important;
+    border: 0 !important;
+    background: #F2D5CF !important;
 }
 .cm-fat-cursor div.CodeMirror-cursors {
-		z-index: 1 !important;
+    z-index: 1 !important;
 }
 .cm-fat-cursor-mark {
-		background-color: rgba(150, 205, 251, 0.5) !important;
+    background-color: rgba(133, 193, 220, 0.50) !important;
 }
 
 .cm-animate-fat-cursor {
-		width: auto !important;
-		border: 0;
-		background-color: var(--ctp-frappe-rosewater) !important;
+    width: auto !important;
+    border: 0;
+    background-color: #F2D5CF !important;
 }
 
 /* Rich Markdown Extra CSS Classes
@@ -533,42 +507,42 @@ Please opt in "Add additional CSS classes for enhanced customization" in plugin
 settings, see https://github.com/CalebJohn/joplin-rich-markdown#extra-css */
 
 .cm-header.cm-rm-header-token {
-	color: var(--ctp-frappe-green) !important;
+  color: #A6D189 !important;
 }
 
 .cm-strong.cm-rm-strong-token {
-	color: var(--ctp-frappe-blue) !important;
+  color: #8CAAEE !important;
 }
 
 pre.cm-rm-blockquote.CodeMirror-line {
-	font-style: italic !important;
+  font-style: italic !important;
 }
 
 /* Command palette coloring */
 
 div.modal-dialog {
-	background-color: var(--ctp-frappe-mantle) !important;
+  background-color: #292C3C !important;
 }
 
 .modal-dialog > div > input {
-	background-color: var(--ctp-frappe-crust) !important;
-	color: var(--ctp-frappe-text) !important;
+  background-color: #232634 !important;
+  color: #C6D0F5 !important;
 }
 
 .modal-dialog > .item-list {
-	background-color: var(--ctp-frappe-crust) !important;
-	color: var(--ctp-frappe-text) !important;
+  background-color: #232634 !important;
+  color: #C6D0F5 !important;
 
 }
 
 .modal-dialog > .item-list div[class="selected"] {
-	background-color: var(--ctp-frappe-surface2) !important;
+  background-color: #626880 !important;
 }
 
 .modal-dialog > .item-list div[class="selected"] > div {
-	color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 .modal-dialog > .item-list > * {
-	color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }

--- a/src/frappe/userchrome.css
+++ b/src/frappe/userchrome.css
@@ -57,7 +57,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-  min-width: 200px !important;
   background-color: #303446 !important;
 }
 

--- a/src/frappe/userstyle.css
+++ b/src/frappe/userstyle.css
@@ -1,38 +1,12 @@
 /* Style for rendered Markdown */
 :root {
-  --ctp-frappe-rosewater: #f2d5cf;
-	--ctp-frappe-flamingo: #eebebe;
-	--ctp-frappe-pink: #f4b8e4;
-	--ctp-frappe-mauve: #ca9ee6;
-	--ctp-frappe-red: #e78284;
-	--ctp-frappe-maroon: #ea999c;
-	--ctp-frappe-peach: #ef9f76;
-	--ctp-frappe-yellow: #e5c890;
-	--ctp-frappe-green: #a6d189;
-	--ctp-frappe-teal: #81c8be;
-	--ctp-frappe-sky: #99d1db;
-	--ctp-frappe-sapphire: #85c1dc;
-	--ctp-frappe-blue: #8caaee;
-	--ctp-frappe-lavender: #babbf1;
-	--ctp-frappe-text: #c6ceef;
-	--ctp-frappe-subtext1: #b5bddc;
-	--ctp-frappe-subtext0: #a5acc9;
-	--ctp-frappe-overlay2: #949bb7;
-	--ctp-frappe-overlay1: #838aa4;
-	--ctp-frappe-overlay0: #737891;
-	--ctp-frappe-surface2: #62677e;
-	--ctp-frappe-surface1: #51566c;
-	--ctp-frappe-surface0: #414559;
-	--ctp-frappe-base: #303446;
-	--ctp-frappe-mantle: #292c3c;
-	--ctp-frappe-crust: #232634;
   --white: #D9E0EE;
   --black: #000000;
   --light: #C9CFFF;
   --lighter-grey: #C3BAC6;
   --light-grey: #988BA2;
 
-	--font-face: "Noto Sans", Arial, Helvetica, sans-serif;
+  --font-face: "Noto Sans", Arial, Helvetica, sans-serif;
   --font-mono: "Roboto Mono", Courier, monospace;
   --font-size: 13px;
   --icon-size: 16px;
@@ -45,29 +19,28 @@
   --opacity-0-8: 0.8;
 }
 
-
 #rendered-md, body, th, td {
-  background-color: var(--ctp-frappe-base) !important;
+  background-color: #303446 !important;
   font-family: var(--font-face) !important;
 }
 
 p, ul, ol, li {
-  color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 strong {
-  color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
 }
 
 hr {
   border: none;
-  border-bottom: 1px solid var(--ctp-frappe-base) !important;
+  border-bottom: 1px solid #303446 !important;
   margin: 2.5em 0 !important;
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar-thumb {
-  background-color: var(--ctp-frappe-base) !important;
+  background-color: #303446 !important;
   border-radius: var(--scroll-radius) !important;
 }
 
@@ -76,7 +49,7 @@ hr {
 *********************************************************************************/
 
 h1 {
-  border-bottom: 1px solid var(--ctp-frappe-base) !important;
+  border-bottom: 1px solid #303446 !important;
   font-weight: var(--bolder) !important;
 }
 
@@ -90,7 +63,7 @@ h2, h3, h4, h5, h6 {
 *********************************************************************************/
 
 a {
-  color: var(--ctp-frappe-rosewater) !important;
+  color: #F2D5CF !important;
   text-decoration: underline !important;
 }
 
@@ -100,7 +73,7 @@ a:hover {
 
 /* Joplin icon in Joplin link */
 .resource-icon {
-  background-color: var(--ctp-frappe-rosewater) !important;
+  background-color: #F2D5CF !important;
 }
 
 /*********************************************************************************
@@ -108,10 +81,10 @@ a:hover {
 *********************************************************************************/
 
 pre, .hljs {
-  background-color: var(--ctp-frappe-mantle) !important;
+  background-color: #292C3C !important;
   font-family: var(--font-mono) !important;
   padding: 10px !important;
-  color: var(--ctp-frappe-text) !important;
+  color: #C6D0F5 !important;
   font-size: 14px !important;
   overflow: scroll !important;
 }
@@ -121,7 +94,7 @@ pre, .hljs {
   background-color: transparent !important;
   border: 0 !important;
   font-family: var(--font-mono) !important;
-  color: var(--ctp-frappe-yellow) !important;
+  color: #E5C890 !important;
   font-size: 14px !important;
 }
 
@@ -130,13 +103,13 @@ pre, .hljs {
 *********************************************************************************/
 
 blockquote {
-  background-color: var(--ctp-frappe-surface0) !important;
+  background-color: #414559 !important;
   padding: 10px !important;
   color: var(--light) !important;
   font-size: 14px !important;
   font-style: italic !important;
   border: 0 !important;
-  border-left: 5px solid var(--ctp-frappe-mantle) !important;
+  border-left: 5px solid #292C3C !important;
 }
 
 /*********************************************************************************
@@ -144,15 +117,15 @@ blockquote {
 *********************************************************************************/
 
 th {
-  border: 1px solid var(--ctp-frappe-text) !important;
-  color: var(--ctp-frappe-text) !important;
-  border-bottom: 1px solid var(--ctp-frappe-text) !important;
+  border: 1px solid #C6D0F5 !important;
+  color: #C6D0F5 !important;
+  border-bottom: 1px solid #C6D0F5 !important;
 }
 
 td {
-  border: 1px solid var(--ctp-frappe-text) !important;
-  color: var(--ctp-frappe-text) !important;
-  border-bottom: 1px solid var(--ctp-frappe-text) !important;
+  border: 1px solid #C6D0F5 !important;
+  color: #C6D0F5 !important;
+  border-bottom: 1px solid #C6D0F5 !important;
 }
 
 /*********************************************************************************
@@ -160,18 +133,18 @@ td {
 *********************************************************************************/
 
 ::selection {
-	background-color: var(--ctp-frappe-lavender) !important;
-  color: var(--ctp-frappe-crust) !important;
+  background-color: #BABBF1 !important;
+  color: #232634 !important;
 }
 
 mark, mark strong {
-  background: var(--ctp-frappe-yellow) !important;
-  color: var(--ctp-frappe-crust) !important;
+  background: #E5C890 !important;
+  color: #232634 !important;
 }
 
 /* Highlighted searched item */
 mark[data-markjs] {
-  background-color: var(--ctp-frappe-lavender) !important;
+  background-color: #BABBF1 !important;
 }
 
 /*********************************************************************************
@@ -189,8 +162,8 @@ mark[data-markjs] {
 /* Container for spoiler title */
 #spoiler-block-title {
   font-family: var(--font-face) !important;
-  color: var(--ctp-frappe-text) !important;
-  background-color: var(--ctp-frappe-mantle) !important;
+  color: #C6D0F5 !important;
+  background-color: #292C3C !important;
   border-radius: 0px;
 }
 
@@ -198,17 +171,17 @@ mark[data-markjs] {
 #spoiler-block-body {
   font-family: var(--font-face) !important;
   color: var(--light) !important;
-  background-color: var(--ctp-frappe-mantle) !important;
+  background-color: #292C3C !important;
   border-radius: 0px;
 }
 
 /* Styling of the spoiler block body */
 .summary-content {
-  background-color: var(--ctp-frappe-mantle) !important;
+  background-color: #292C3C !important;
 }
 
 .summary-title:before {
-  color: var(--ctp-frappe-lavender) !important;
+  color: #BABBF1 !important;
 }
 
 /*********************************************************************************
@@ -259,7 +232,7 @@ mark[data-markjs] {
   }
 
   a {
-    color: var(--ctp-frappe-red) !important;
+    color: #E78284 !important;
     text-decoration: underline !important;
   }
 
@@ -268,7 +241,7 @@ mark[data-markjs] {
   background-color: #F8F8F8 !important;
   border: 0 !important;
   font-family: var(--font-mono) !important;
-  /* color: var(--ctp-frappe-yellow) !important; */
+  /* color: #E5C890 !important; */
   font-size: 14px !important;
 }
 
@@ -276,7 +249,7 @@ pre, .hljs {
   background-color: #F8F8F8 !important;
   font-family: var(--font-mono) !important;
   padding: 10px !important;
-  color: var(--ctp-frappe-crust) !important;
+  color: #232634 !important;
   font-size: 14px !important;
   overflow: scroll !important;
 }
@@ -284,7 +257,7 @@ pre, .hljs {
 blockquote {
   background-color: #F8F8F8 !important;
   padding: 10px !important;
-  color: var(--ctp-frappe-crust) !important;
+  color: #232634 !important;
   font-size: 14px !important;
   font-style: italic !important;
   border: 0 !important;

--- a/src/latte/userchrome.css
+++ b/src/latte/userchrome.css
@@ -1,45 +1,19 @@
 /* Original theme at https://github.com/stysebae/joplin-vsc-material-theme, modified for Catppuccin. */
 /* For styling the entire Joplin app (except the rendered Markdown, which is defined in `userstyle.css`) */
+
 :root {
-	--ctp-latte-rosewater: #de9584;
-	--ctp-latte-flamingo: #dd7878;
-	--ctp-latte-pink: #ec83d0;
-	--ctp-latte-mauve: #8839ef;
-	--ctp-latte-red: #d20f39;
-	--ctp-latte-maroon: #e64553;
-	--ctp-latte-peach: #fe640b;
-	--ctp-latte-yellow: #e49320;
-	--ctp-latte-green: #40a02b;
-	--ctp-latte-teal: #179299;
-	--ctp-latte-sky: #04a5e5;
-	--ctp-latte-sapphire: #209fb5;
-	--ctp-latte-blue: #2a6ef5;
-	--ctp-latte-lavender: #7287fd;
-	--ctp-latte-text: #4c4f69;
-	--ctp-latte-subtext1: #5c5f77;
-	--ctp-latte-subtext0: #6c6f85;
-	--ctp-latte-overlay2: #7c7f93;
-	--ctp-latte-overlay1: #8c8fa1;
-	--ctp-latte-overlay0: #9ca0b0;
-	--ctp-latte-surface2: #acb0be;
-	--ctp-latte-surface1: #bcc0cc;
-	--ctp-latte-surface0: #ccd0da;
-	--ctp-latte-base: #eff1f5;
-	--ctp-latte-mantle: #e6e9ef;
-	--ctp-latte-crust: #dce0e8;
-	--font-face: "Noto Sans", Arial, Helvetica, sans-serif;
-	--font-mono: "Roboto Mono", Courier, monospace;
-	--font-size: 13px;
-	--icon-size: 16px;
+  --font-face: "Noto Sans", Arial, Helvetica, sans-serif;
+  --font-mono: "Roboto Mono", Courier, monospace;
+  --font-size: 13px;
+  --icon-size: 16px;
 
-	--regular: 400;
-	--bolder: 600;
+  --regular: 400;
+  --bolder: 600;
 
-	--scroll-radius: 3px;
+  --scroll-radius: 3px;
 
-	--opacity-0-8: 0.8;
+  --opacity-0-8: 0.8;
 }
-
 
 /* Font used by Joplin */
 * {
@@ -47,7 +21,7 @@
 }
 
 html, body {
-  background-color: var(--ctp-latte-base) !important;
+  background-color: #EFF1F5 !important;
   font-size: var(--font-size) !important;
   font-weight: var(--regular) !important;
   color: var(--light) !important;
@@ -57,7 +31,7 @@ html, body {
     background: #6B6B6B !important;
 }
 .rli-root {
-  background-color: var(--ctp-latte-base) !important;
+  background-color: #EFF1F5 !important;
 }
 
 /* Icons */
@@ -68,12 +42,12 @@ html, body {
 }
 
 ::placeholder {
-  color: var(--ctp-latte-lavender) !important;
+  color: #7287FD !important;
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar-thumb {
-  background-color: var(--ctp-latte-surface0) !important;
+  background-color: #CCD0DA !important;
   border-radius: var(--scroll-radius) !important;
 }
 
@@ -84,7 +58,7 @@ html, body {
 /* General panel style */
 .resizableLayoutItem > div {
   min-width: 200px !important;
-  background-color: var(--ctp-latte-base) !important;
+  background-color: #EFF1F5 !important;
 }
 
 /*********************************************************************************
@@ -92,13 +66,9 @@ html, body {
 *********************************************************************************/
 
 .sidebar {
-  background-color: var(--ctp-latte-crust) !important;
+  background-color: #DCE0E8 !important;
   text-transform: uppercase;
   font-weight: var(--bolder);
-}
-
-.bWPSUP > i, .bWPSUP > span {
-  color: var(--ctp-latte-text) !important;
 }
 
 /* Hide "All notes" icon
@@ -111,76 +81,65 @@ i.icon-notes {
 
 /* "Add new notebook" button */
 .sidebar > div > div > button span {
-  color: var(--ctp-latte-lavender) !important;
+  color: #7287FD !important;
 }
-div.sc-fzoyTs.eIbLtS span.sc-fzpmMD.eNteRa {
-	color: var(--ctp-latte-text) !important;
-}
-div.sc-fzoyTs.eIbLtS i.sc-fzoNJl.blQlSy.icon-notebooks, i.sc-fzoNJl.blQlSy.icon-tags::before {
-	color: var(--ctp-latte-text) !important;
-}
+
 .sidebar > div > div > button:hover {
   opacity: var(--opacity-0-8);
 }
 .folders .list-item-container {
-    background-color: var(--ctp-latte-crust) !important;
+    background-color: #DCE0E8 !important;
 }
 .folders .list-item-container:hover {
-  background-color: var(--ctp-latte-overlay0) !important;
-}
-div.sc-fzqBkg.dDQgvd.note-count-label {
-	color: var(--ctp-latte-text) !important;
+  background-color: #9CA0B0 !important;
 }
 
 .folders .list-item-container a {
   text-transform: initial;
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
   font-weight: var(--regular);
 }
 
 .folders .list-item-container a:focus {
-  color: var(--ctp-latte-text) !important;
-  background-color: var(--ctp-latte-base) !important;
+  color: #4C4F69 !important;
+  background-color: #EFF1F5 !important;
 }
 
 .folders .list-item-container a:hover {
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
 }
 
-.note-count-label {
-  color: var(--ctp-latte-subtext1) !important;
-}
 /* TAGS */
 .tags .list-item-container {
     display: inline-block;
     line-height: 0 !important;
     padding: 0 !important;
     height: auto !important;
-    background-color: var(--ctp-latte-crust) !important;
+    background-color: #DCE0E8 !important;
 }
 .tags .list-item-container:hover {
   display: inline-block;
   line-height: 0 !important;
   padding: 0 !important;
   height: auto !important;
-  background-color: var(--ctp-latte-overlay0) !important;
+  background-color: #9CA0B0 !important;
 }
 
 .tags .list-item-container a {
   padding-left: 12px !important;
   text-transform: initial;
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
   font-weight: var(--regular);
 }
 
 .tags .list-item-container a:focus {
-  color: var(--ctp-latte-text) !important;
-  background-color: var(--ctp-latte-base) !important;
+  color: #4C4F69 !important;
+  background-color: #EFF1F5 !important;
 }
 
 .tags .list-item-container a:hover {
-  color: var(--ctp-latte-text) !important;
-  background-color: var(--ctp-latte-overlay0) !important;
+  color: #4C4F69 !important;
+  background-color: #9CA0B0 !important;
 }
 
 /* SYNCHRONIZATION */
@@ -190,7 +149,7 @@ div.sc-fzqBkg.dDQgvd.note-count-label {
 }
 
 .sidebar > div:last-of-type > button {
-  background-color: var(--ctp-latte-lavender) !important;
+  background-color: #7287FD !important;
   border: 0px !important;
   text-transform: uppercase;
   font-size: var(--font-size) !important;
@@ -201,29 +160,21 @@ div.sc-fzqBkg.dDQgvd.note-count-label {
 }
 
 .sidebar > div:last-of-type > button > span {
-  /* color: var(--ctp-latte-crust) !important; */
-  color: var(--ctp-latte-text) !important;
-}
-.sc-fzoYkl.gYkyEX {
-	color: var(--ctp-latte-text) !important;
+  color: #DCE0E8 !important;
 }
 
-/* Sync complete information */
-.hdpRiC {
-  color: var(--ctp-latte-text) !important;
-}
 /*********************************************************************************
 *NOTE LIST
 *********************************************************************************/
 
 .note-list {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #E6E9EF !important;
   border: none !important;
 }
 
 /* Empty notelist */
 .cLdGCO, .cLdGCO > div {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #E6E9EF !important;
 }
 
 /* Remove border - introduced in 1.3.7 */
@@ -234,18 +185,18 @@ div.sc-fzqBkg.dDQgvd.note-count-label {
 /* BUTTONS SEARCH, SORT NOTES, NEW NOTE AND NEW TASK */
 
 div[height="50"] {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #E6E9EF !important;
 }
 
 div[height="50"] input {
   border: none !important;
-  color: var(--ctp-latte-text) !important;
-  background-color: var(--ctp-latte-mantle) !important;
+  color: #4C4F69 !important;
+  background-color: #E6E9EF !important;
 }
 
 div[height="50"] button {
   background: transparent !important;
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
   border: 0 !important;
 }
 
@@ -254,54 +205,49 @@ div[height="50"] button:hover {
 }
 
 div[height="50"] button span {
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
 }
 
-.chwTAE {
-  background-color: var(--ctp-latte-mantle) !important;
-}
-
-.sc-hCPjZK.fJjcQe {
-  background-color: var(--ctp-latte-mantle) !important;
+.sc-hCPjZK.fJjcQe{
+  background-color: #E6E9EF !important;
 }
 .new-note-todo-buttons > button {
-  background-color: var(--ctp-latte-lavender) !important;
+  background-color: #7287FD !important;
   border: none !important;
 }
 .new-todo-button > span {
-  color: var(--ctp-latte-mantle) !important;
+  color: #DCE0E8 !important;
 }
 
 .search-bar {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #DCE0E8 !important;
 }
 
 .icon-search {
-  color: var(--ctp-latte-lavender) !important;
+  color: #7287FD !important;
 }
 
 .sort-order-reverse-button {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #DCE0E8 !important;
 }
 .sort-order-reverse-button {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #DCE0E8 !important;
 }
 
 .fa-calendar-alt {
-  color: var(--ctp-latte-lavender) !important;
+  color: #7287FD !important;
 }
 .fa-long-arrow-alt-up {
-  color: var(--ctp-latte-lavender) !important;
+  color: #7287FD !important;
 }
-
 /* LIST OF NOTES */
 
 .note-list .list-item-container {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #E6E9EF !important;
 }
 
 .note-list .list-item-container:hover {
-  background-color: var(--ctp-latte-overlay1) !important;
+  background-color: #8C8FA1 !important;
 }
 
 .item-list.note-list .list-item-container::before {
@@ -310,17 +256,17 @@ div[height="50"] button span {
 
 .note-list .list-item-container a {
   text-transform: initial;
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
   font-weight: var(--regular);
 }
 
 .note-list .list-item-container a:focus {
-  color: var(--ctp-latte-text) !important;
-  background-color: var(--ctp-latte-base) !important;
+  color: #4C4F69 !important;
+  background-color: #EFF1F5 !important;
 }
 
 .note-list .list-item-container a:hover {
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
 }
 
 /* Add "..." to notes with long titles */
@@ -334,40 +280,30 @@ div[height="50"] button span {
 *********************************************************************************/
 
 /* EDITOR TOOLBAR */
-input.title-input {
-	padding-top: 5px;
-	color: var(--ctp-latte-text) !important;
-	background-color: var(--ctp-latte-base) !important;
 
+/* Title */
+/* Changes frequently with updates, need to keep tabs */
+.rli-editor .cCOtNv > input {
+  padding-top: 5px;
+  background-color: #EFF1F5 !important;
+}
+
+.title-input {
+  background-color: #EFF1F5 !important;
+  color: #4C4F69 !important;
 }
 
 .editor-toolbar {
   background-color: transparent !important;
 }
-/* Editor toolbar buttons */
-
-.editor-toolbar > div > a > span {
-	  color: var(--ctp-latte-text) !important;
-}
-
-.editor-toolbar > div > a > span::hover {
-	color: var(--ctp-latte-lavender) !important;
-}
 
 .editor-toolbar > div > a:hover {
   opacity: var(--opacity-0-8);
-  color: var(--ctp-latte-lavender) !important;
-  background-color: var(--ctp-latte-overlay0) !important;
 }
 
 /* Hide "Spell checker" button */
 .editor-toolbar a[title="Spell checker"] {
-display: none !important;
-}
-
-div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
-  background-color: var(--ctp-latte-mantle) !important;
-  color: var(--ctp-latte-text) !important;
+ display: none !important;
 }
 
 /* Hide "Markdown/Richtext editor" Button */
@@ -375,13 +311,14 @@ div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
  display: none !important;
 }
 
+/* Hide the Toggle editors button */
 .editor-toolbar button[title="Toggle editors"] {
   display: none !important;
 }
 
 /* Breadcrumbs (In:...) - Used in tag listings */
 .cJOYJm {
-  background-color: var(--ctp-latte-lavender) !important;
+  background-color: #7287FD !important;
   margin: 0px !important;
   padding: 5px !important;
   font-size: var(--font-size) !important;
@@ -394,17 +331,22 @@ div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
 /* CONTENT */
 /* Empty notebook */
 .rli-editor > div > div:empty {
-  background-color: var(--ctp-latte-base) !important;
+  background-color: #EFF1F5 !important;
 }
 
 /* Editor layout splitter */
 .rli-editor > div > div > div > div > div > div > div:last-of-type {
-  border-color: var(--ctp-latte-base) !important;
+  border-color: #EFF1F5 !important;
+}
+
+div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
+  background-color: #E6E9EF !important;
+  color: #4C4F69 !important;
 }
 
 /* NOTE SEARCH BAR */
 .note-search-bar, .note-search-bar > div > div {
-  background-color: var(--ctp-latte-base) !important;
+  background-color: #EFF1F5 !important;
   width: 100%;
   border: 0 !important;
 }
@@ -412,8 +354,8 @@ div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
 .note-search-bar input {
   border: 0 !important;
   padding: 5px;
-  color: var(--ctp-latte-text) !important;
-  background-color: var(--ctp-latte-base) !important;
+  color: #4C4F69 !important;
+  background-color: #EFF1F5 !important;
 }
 
 /* TAGS */
@@ -422,8 +364,8 @@ div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
 }
 
 .tag-list > span {
-  color: var(--ctp-latte-lavender) !important;
-  background-color: var(--ctp-latte-crust) !important;
+  color: #7287FD !important;
+  background-color: #DCE0E8 !important;
 }
 
 /* Hide "Click to add tags..."*/
@@ -436,149 +378,128 @@ a[Title="Tags"] + div > span {
 *********************************************************************************/
 
 .cm-s-material-darker.CodeMirror {
-  background-color: var(--ctp-latte-base) !important;
-  color: var(--ctp-latte-text) !important;
+  background-color: #EFF1F5 !important;
+  color: #4C4F69 !important;
 }
 
-.CodeMirror-lines {
-  background-color: var(--ctp-latte-base) !important;
-}
 /* Header */
 .cm-header {
-  color: var(--ctp-latte-lavender) !important;
+  color: #7287FD !important;
 }
 
 /* Italics/Emphasis, Bold, BoldItalics */
 .cm-em, .cm-strong, .cm-strong.cm-em {
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
 }
 
 /* Lists (Bullet/number/todo) */
 .cm-variable-2, .cm-variable-3, .cm-keyword {
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
 }
 
 .cm-s-material-darker .cm-variable-2.cm-rm-list-token {
-	color: var(--ctp-latte-text) !important;
-}
-
-.CodeMirror-vscrollbar {
-  background-color: var(--ctp-latte-base) !important;
+  color: #4C4F69 !important;
 }
 
 /* Links (link) */
 .cm-url {
-  color: var(--ctp-latte-rosewater) !important;
+  color: #DC8A78 !important;
   opacity: 1;
   text-decoration: underline;
 }
 
 /* Links (text) */
 .cm-link-text {
-  color: var(--ctp-latte-rosewater) !important;
+  color: #DC8A78 !important;
 }
 pre.CodeMirror-line {
-    color: var(--ctp-latte-text) !important;
+    color: #4C4F69 !important;
     background-color: none !important;
 }
 /* Image link in editor */
 span.cm-string.cm-url.cm-overlay.cm-rm-link.cm-overlay.cm-rm-image {
-  color: var(--ctp-latte-lavender) !important;
+  color: #7287FD !important;
 }
 /* Comment outside code block */
 pre.CodeMirror-line span.cm-comment {
-	color: var(--ctp-latte-overlay1) !important;
+  color: #8C8FA1 !important;
   background-color: none !important;
   border: 0 !important;
 }
 
 /* Codeblock selection colour */
-
 /* For some reason, the CodeMirror selection does not pick the colour correctly, left for now. */
 pre.CodeMirror-line span.CodeMirror-selectedtext {
-	/* background: var(--ctp-latte-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #ACB0BE !important; */
+  background: #6B6B6B !important;
 }
 
 div[class^="cm-jn-code-block-background "]::selection {
-  background-color: var(--ctp-latte-base) !important;
-  border-color: var(--ctp-latte-base) !important;
+  background-color: #EFF1F5 !important;
+  border-color: #EFF1F5 !important;
 }
 
 pre.cm-jn-code-block.CodeMirror-line span.cm-comment.cm-jn-monospace.CodeMirror-selectedtext {
-	/* background: var(--ctp-latte-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #ACB0BE !important; */
+  background: #6B6B6B !important;
 }
 pre.cm-jn-code-block.CodeMirror-line::selection {
-	/* background: var(--ctp-latte-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #ACB0BE !important; */
+  background: #6B6B6B !important;
 }
 div.cm-jn-code-block-background.CodeMirror-linebackground::selection {
-	/* background: var(--ctp-latte-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #ACB0BE !important; */
+  background: #6B6B6B !important;
 }
 pre.cm-jn-code-block.CodeMirror-line::selection span {
-	/* background: var(--ctp-latte-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #ACB0BE !important; */
+  background: #6B6B6B !important;
 }
 
 div.CodeMirror span.cm-comment.cm-jn-inline-code {
-	background-color: transparent !important;
-	padding-right: 0 !important;
+  background-color: transparent !important;
+  padding-right: 0 !important;
   padding-left: 0 !important;
 }
 
 /* Code Block Text */
 div.CodeMirror span.cm-comment:not(.cm-jn-inline-code) {
-  color: var(--ctp-latte-text) !important;
-  background-color: transparent !important;
-}
-span.cm-string.cm-jn-monospace{
-	  color: var(--ctp-latte-green) !important;
-  background-color: transparent !important;
-}
-span.cm-meta.cm-jn-monospace, span.cm-builtin.cm-jn-monospace, span.cm-type.cm-jn-monospace {
-	  color: var(--ctp-latte-yellow) !important;
+  color: #4C4F69 !important;
   background-color: transparent !important;
 }
 
 /* Code block background */
-
 div.CodeMirror div.cm-jn-code-block-background {
-    background-color: var(--ctp-latte-mantle) !important;
-}
-
-span.cm-operator.cm-jn-monospace {
-	color: var(--ctp-latte-blue) !important;
+    background-color: #E6E9EF !important;
 }
 
 /* Horizontal Line */
 .cm-hr {
-  color: var(--ctp-latte-overlay0) !important;
+  color: #9CA0B0 !important;
 }
 
 /* Cursor colour */
 .CodeMirror-cursor {
-    border-left: 1px solid var(--ctp-latte-rosewater) !important;
+    border-left: 1px solid #DC8A78 !important;
     border-right: none !important;
     width: 0 !important;
 }
 .cm-fat-cursor div.CodeMirror-cursor {
     width: 10px !important;
     border: 0 !important;
-    background: var(--ctp-latte-rosewater) !important;
+    background: #DC8A78 !important;
 }
 .cm-fat-cursor div.CodeMirror-cursors {
     z-index: 1 !important;
 }
 .cm-fat-cursor-mark {
-    background-color: rgba(150, 205, 251, 0.5) !important;
+    background-color: rgba(32, 159, 181, 0.50) !important;
 }
 
 .cm-animate-fat-cursor {
     width: auto !important;
     border: 0;
-    background-color: var(--ctp-latte-rosewater) !important;
+    background-color: #DC8A78 !important;
 }
 
 /* Rich Markdown Extra CSS Classes
@@ -586,11 +507,11 @@ Please opt in "Add additional CSS classes for enhanced customization" in plugin
 settings, see https://github.com/CalebJohn/joplin-rich-markdown#extra-css */
 
 .cm-header.cm-rm-header-token {
-  color: var(--ctp-latte-green) !important;
+  color: #40A02B !important;
 }
 
 .cm-strong.cm-rm-strong-token {
-  color: var(--ctp-latte-blue) !important;
+  color: #1E66F5 !important;
 }
 
 pre.cm-rm-blockquote.CodeMirror-line {
@@ -600,40 +521,28 @@ pre.cm-rm-blockquote.CodeMirror-line {
 /* Command palette coloring */
 
 div.modal-dialog {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #E6E9EF !important;
 }
 
 .modal-dialog > div > input {
-  background-color: var(--ctp-latte-crust) !important;
-  color: var(--ctp-latte-text) !important;
+  background-color: #DCE0E8 !important;
+  color: #4C4F69 !important;
 }
 
 .modal-dialog > .item-list {
-  background-color: var(--ctp-latte-crust) !important;
-  color: var(--ctp-latte-text) !important;
+  background-color: #DCE0E8 !important;
+  color: #4C4F69 !important;
 
 }
 
 .modal-dialog > .item-list div[class="selected"] {
-  background-color: var(--ctp-latte-surface2) !important;
-}
-
-.modal-dialog > .item-list div[class="selected"] > div > span {
-  color: var(--ctp-latte-text) !important;
-}
-
-.modal-dialog > .item-list div:not(div[class="selected"]) > div > span{
-  color: var(--ctp-latte-text) !important;
+  background-color: #ACB0BE !important;
 }
 
 .modal-dialog > .item-list div[class="selected"] > div {
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
 }
 
-.modal-dialog > .item-list > div:not(div[class="selected"]) > div {
-  color: var(--ctp-latte-text) !important;
-}
-
-.fa-question-circle {
-  color: var(--ctp-latte-text) !important;
+.modal-dialog > .item-list > * {
+  color: #4C4F69 !important;
 }

--- a/src/latte/userchrome.css
+++ b/src/latte/userchrome.css
@@ -57,7 +57,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-  min-width: 200px !important;
   background-color: #EFF1F5 !important;
 }
 

--- a/src/latte/userstyle.css
+++ b/src/latte/userstyle.css
@@ -1,45 +1,17 @@
 /* Style for rendered Markdown */
-
 :root {
-  --ctp-latte-rosewater: #de9584;
-	--ctp-latte-flamingo: #dd7878;
-	--ctp-latte-pink: #ec83d0;
-	--ctp-latte-mauve: #8839ef;
-	--ctp-latte-red: #d20f39;
-	--ctp-latte-maroon: #e64553;
-	--ctp-latte-peach: #fe640b;
-	--ctp-latte-yellow: #e49320;
-	--ctp-latte-green: #40a02b;
-	--ctp-latte-teal: #179299;
-	--ctp-latte-sky: #04a5e5;
-	--ctp-latte-sapphire: #209fb5;
-	--ctp-latte-blue: #2a6ef5;
-	--ctp-latte-lavender: #7287fd;
-	--ctp-latte-text: #4c4f69;
-	--ctp-latte-subtext1: #5c5f77;
-	--ctp-latte-subtext0: #6c6f85;
-	--ctp-latte-overlay2: #7c7f93;
-	--ctp-latte-overlay1: #8c8fa1;
-	--ctp-latte-overlay0: #9ca0b0;
-	--ctp-latte-surface2: #acb0be;
-	--ctp-latte-surface1: #bcc0cc;
-	--ctp-latte-surface0: #ccd0da;
-	--ctp-latte-base: #eff1f5;
-	--ctp-latte-mantle: #e6e9ef;
-	--ctp-latte-crust: #dce0e8;
- --white: #D9E0EE;
+  --white: #D9E0EE;
   --black: #000000;
   --light: #C9CFFF;
   --lighter-grey: #C3BAC6;
   --light-grey: #988BA2;
 
-	--font-face: "Noto Sans", Arial, Helvetica, sans-serif;
+  --font-face: "Noto Sans", Arial, Helvetica, sans-serif;
   --font-mono: "Roboto Mono", Courier, monospace;
   --font-size: 13px;
   --icon-size: 16px;
 
   --regular: 400;
-  --bolder: 500;
   --bolder: 600;
 
   --scroll-radius: 3px;
@@ -48,27 +20,27 @@
 }
 
 #rendered-md, body, th, td {
-  background-color: var(--ctp-latte-base) !important;
+  background-color: #EFF1F5 !important;
   font-family: var(--font-face) !important;
 }
 
 p, ul, ol, li {
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
 }
 
 strong {
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
 }
 
 hr {
   border: none;
-  border-bottom: 1px solid var(--ctp-latte-base) !important;
+  border-bottom: 1px solid #EFF1F5 !important;
   margin: 2.5em 0 !important;
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar-thumb {
-  background-color: var(--ctp-latte-base) !important;
+  background-color: #EFF1F5 !important;
   border-radius: var(--scroll-radius) !important;
 }
 
@@ -77,15 +49,13 @@ hr {
 *********************************************************************************/
 
 h1 {
-  color: var(--ctp-latte-text) !important;
-  border-bottom: 1px solid var(--ctp-latte-base) !important;
+  border-bottom: 1px solid #EFF1F5 !important;
   font-weight: var(--bolder) !important;
 }
 
 h2, h3, h4, h5, h6 {
-  color: var(--ctp-latte-text) !important;
   border-bottom: 0 !important;
-  font-weight: var(--bold) !important;
+  font-weight: var(--regular) !important;
 }
 
 /*********************************************************************************
@@ -93,7 +63,7 @@ h2, h3, h4, h5, h6 {
 *********************************************************************************/
 
 a {
-  color: var(--ctp-latte-rosewater) !important;
+  color: #DC8A78 !important;
   text-decoration: underline !important;
 }
 
@@ -103,7 +73,7 @@ a:hover {
 
 /* Joplin icon in Joplin link */
 .resource-icon {
-  background-color: var(--ctp-latte-rosewater) !important;
+  background-color: #DC8A78 !important;
 }
 
 /*********************************************************************************
@@ -111,10 +81,10 @@ a:hover {
 *********************************************************************************/
 
 pre, .hljs {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #E6E9EF !important;
   font-family: var(--font-mono) !important;
   padding: 10px !important;
-  color: var(--ctp-latte-text) !important;
+  color: #4C4F69 !important;
   font-size: 14px !important;
   overflow: scroll !important;
 }
@@ -124,17 +94,8 @@ pre, .hljs {
   background-color: transparent !important;
   border: 0 !important;
   font-family: var(--font-mono) !important;
-  color: var(--ctp-latte-blue) !important;
+  color: #DF8E1D !important;
   font-size: 14px !important;
-}
-pre, .hljs-params {
-	color: var(--ctp-latte-red) !important;
-}
-pre, .hljs-string {
-	color: var(--ctp-latte-blue	) !important;
-}
-pre, .hljs-built_in {
-	color: var(--ctp-latte-yellow) !important;
 }
 
 /*********************************************************************************
@@ -142,28 +103,29 @@ pre, .hljs-built_in {
 *********************************************************************************/
 
 blockquote {
-  background-color: var(--ctp-latte-surface0) !important;
+  background-color: #CCD0DA !important;
   padding: 10px !important;
   color: var(--light) !important;
   font-size: 14px !important;
   font-style: italic !important;
   border: 0 !important;
-  border-left: 5px solid var(--ctp-latte-mantle) !important;
+  border-left: 5px solid #E6E9EF !important;
 }
 
 /*********************************************************************************
 * TABLES
 *********************************************************************************/
+
 th {
-  border: 1px solid var(--ctp-latte-text) !important;
-  color: var(--ctp-latte-text) !important;
-  border-bottom: 1px solid var(--ctp-latte-text) !important;
+  border: 1px solid #4C4F69 !important;
+  color: #4C4F69 !important;
+  border-bottom: 1px solid #4C4F69 !important;
 }
 
 td {
-  border: 1px solid var(--ctp-latte-text) important;
-  color: var(--ctp-latte-text) !important;
-  border-bottom: 1px solid var(--ctp-latte-text) !important;
+  border: 1px solid #4C4F69 !important;
+  color: #4C4F69 !important;
+  border-bottom: 1px solid #4C4F69 !important;
 }
 
 /*********************************************************************************
@@ -171,18 +133,18 @@ td {
 *********************************************************************************/
 
 ::selection {
-	background-color: var(--ctp-latte-lavender) !important;
-  color: var(--ctp-latte-crust) !important;
+  background-color: #7287FD !important;
+  color: #DCE0E8 !important;
 }
 
 mark, mark strong {
-  background: var(--ctp-latte-yellow) !important;
-  color: var(--ctp-latte-crust) !important;
+  background: #DF8E1D !important;
+  color: #DCE0E8 !important;
 }
 
 /* Highlighted searched item */
 mark[data-markjs] {
-  background-color: var(--ctp-latte-lavender) !important;
+  background-color: #7287FD !important;
 }
 
 /*********************************************************************************
@@ -200,8 +162,8 @@ mark[data-markjs] {
 /* Container for spoiler title */
 #spoiler-block-title {
   font-family: var(--font-face) !important;
-  color: var(--ctp-latte-text) !important;
-  background-color: var(--ctp-latte-mantle) !important;
+  color: #4C4F69 !important;
+  background-color: #E6E9EF !important;
   border-radius: 0px;
 }
 
@@ -209,17 +171,17 @@ mark[data-markjs] {
 #spoiler-block-body {
   font-family: var(--font-face) !important;
   color: var(--light) !important;
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #E6E9EF !important;
   border-radius: 0px;
 }
 
 /* Styling of the spoiler block body */
 .summary-content {
-  background-color: var(--ctp-latte-mantle) !important;
+  background-color: #E6E9EF !important;
 }
 
 .summary-title:before {
-  color: var(--ctp-latte-lavender) !important;
+  color: #7287FD !important;
 }
 
 /*********************************************************************************
@@ -241,7 +203,6 @@ mark[data-markjs] {
   strong {
     color: var(--black) !important;
   }
-
   th {
   border: 1px solid var(--black) !important;
   color: var(--black) !important;
@@ -271,7 +232,7 @@ mark[data-markjs] {
   }
 
   a {
-    color: var(--ctp-latte-red) !important;
+    color: #D20F39 !important;
     text-decoration: underline !important;
   }
 
@@ -280,23 +241,23 @@ mark[data-markjs] {
   background-color: #F8F8F8 !important;
   border: 0 !important;
   font-family: var(--font-mono) !important;
-  /* color: var(--ctp-latte-yellow) !important; */
+  /* color: #DF8E1D !important; */
   font-size: 14px !important;
 }
 
 pre, .hljs {
-  background-color: #F8F8F8!important;
+  background-color: #F8F8F8 !important;
   font-family: var(--font-mono) !important;
   padding: 10px !important;
-  color: var(--ctp-latte-crust) !important;
+  color: #DCE0E8 !important;
   font-size: 14px !important;
   overflow: scroll !important;
 }
 
 blockquote {
-  background-color: #F8F8F8!important;
+  background-color: #F8F8F8 !important;
   padding: 10px !important;
-  color: var(--ctp-latte-crust) !important;
+  color: #DCE0E8 !important;
   font-size: 14px !important;
   font-style: italic !important;
   border: 0 !important;

--- a/src/macchiato/userchrome.css
+++ b/src/macchiato/userchrome.css
@@ -2,79 +2,53 @@
 /* For styling the entire Joplin app (except the rendered Markdown, which is defined in `userstyle.css`) */
 
 :root {
-	--ctp-macchiato-rosewater: #f4dbd6;
-	--ctp-macchiato-flamingo: #f0c6c6;
-	--ctp-macchiato-pink: #f5bde6;
-	--ctp-macchiato-mauve: #c6a0f6;
-	--ctp-macchiato-red: #ed8796;
-	--ctp-macchiato-maroon: #ee99a0;
-	--ctp-macchiato-peach: #f5a97f;
-	--ctp-macchiato-yellow: #eed49f;
-	--ctp-macchiato-green: #a6da95;
-	--ctp-macchiato-teal: #8bd5ca;
-	--ctp-macchiato-sky: #91d7e3;
-	--ctp-macchiato-sapphire: #7dc4e4;
-	--ctp-macchiato-blue: #8aadf4;
-	--ctp-macchiato-lavender: #b7bdf8;
-	--ctp-macchiato-text: #c5cff5;
-	--ctp-macchiato-subtext1: #b3bce0;
-	--ctp-macchiato-subtext0: #a1aacb;
-	--ctp-macchiato-overlay2: #8f97b7;
-	--ctp-macchiato-overlay1: #7d84a2;
-	--ctp-macchiato-overlay0: #6c728d;
-	--ctp-macchiato-surface2: #5a5f78;
-	--ctp-macchiato-surface1: #484c64;
-	--ctp-macchiato-surface0: #363a4f;
-	--ctp-macchiato-base: #24273a;
-	--ctp-macchiato-mantle: #1e2030;
-	--ctp-macchiato-crust: #181926;
-	--font-face: "Noto Sans", Arial, Helvetica, sans-serif;
-	--font-mono: "Roboto Mono", Courier, monospace;
-	--font-size: 13px;
-	--icon-size: 16px;
+  --font-face: "Noto Sans", Arial, Helvetica, sans-serif;
+  --font-mono: "Roboto Mono", Courier, monospace;
+  --font-size: 13px;
+  --icon-size: 16px;
 
-	--regular: 400;
-	--bolder: 600;
+  --regular: 400;
+  --bolder: 600;
 
-	--scroll-radius: 3px;
+  --scroll-radius: 3px;
 
-	--opacity-0-8: 0.8;
+  --opacity-0-8: 0.8;
 }
 
 /* Font used by Joplin */
 * {
-	font-family: var(--font-face) !important;
+  font-family: var(--font-face) !important;
 }
 
 html, body {
-	background-color: var(--ctp-macchiato-base) !important;
-	font-size: var(--font-size) !important;
-	font-weight: var(--regular) !important;
-	color: var(--light) !important;
+  background-color: #24273A !important;
+  font-size: var(--font-size) !important;
+  font-weight: var(--regular) !important;
+  color: var(--light) !important;
 }
 .CodeMirror-selected {
-		/* background-color: var(--lighter-grey) !important; */
-		background: #6B6B6B !important;
+    /* background-color: var(--lighter-grey) !important; */
+    background: #6B6B6B !important;
 }
 .rli-root {
-	background-color: var(--ctp-macchiato-base) !important;
+  background-color: #24273A !important;
 }
 
 /* Icons */
 .fa, .far, .fas {
-	font-weight: 900 !important;
-	font-family: "Font Awesome 5 Free" !important;
-	font-size: var(--icon-size) !important;
+  font-weight: 900 !important;
+  font-family: "Font Awesome 5 Free" !important;
+  font-size: var(--icon-size) !important;
 }
 
 ::placeholder {
-	color: var(--ctp-macchiato-lavender) !important;
+  color: #B7BDF8 !important;
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar-thumb {
-	background-color: var(--ctp-macchiato-surface0) !important;
-	border-radius: var(--scroll-radius) !important;
+  background-color: #363A4F !important;
+  border-radius: var(--scroll-radius) !important;
 }
 
 /*********************************************************************************
@@ -83,8 +57,8 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-	min-width: 200px !important;
-	background-color: var(--ctp-macchiato-base) !important;
+  min-width: 200px !important;
+  background-color: #24273A !important;
 }
 
 /*********************************************************************************
@@ -92,101 +66,101 @@ html, body {
 *********************************************************************************/
 
 .sidebar {
-	background-color: var(--ctp-macchiato-crust) !important;
-	text-transform: uppercase;
-	font-weight: var(--bolder);
+  background-color: #181926 !important;
+  text-transform: uppercase;
+  font-weight: var(--bolder);
 }
 
 /* Hide "All notes" icon
  * Comment this next block if you want the "All notes" icon */
 i.icon-notes {
-	display: none !important;
+  display: none !important;
 }
 
 /* FOLDERS */
 
 /* "Add new notebook" button */
 .sidebar > div > div > button span {
-	color: var(--ctp-macchiato-lavender) !important;
+  color: #B7BDF8 !important;
 }
 
 .sidebar > div > div > button:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 .folders .list-item-container {
-		background-color: var(--ctp-macchiato-crust) !important;
+    background-color: #181926 !important;
 }
 .folders .list-item-container:hover {
-	background-color: var(--ctp-macchiato-overlay0) !important;
+  background-color: #6E738D !important;
 }
 
 .folders .list-item-container a {
-	text-transform: initial;
-	color: var(--ctp-macchiato-text) !important;
-	font-weight: var(--regular);
+  text-transform: initial;
+  color: #CAD3F5 !important;
+  font-weight: var(--regular);
 }
 
 .folders .list-item-container a:focus {
-	color: var(--ctp-macchiato-text) !important;
-	background-color: var(--ctp-macchiato-base) !important;
+  color: #CAD3F5 !important;
+  background-color: #24273A !important;
 }
 
 .folders .list-item-container a:hover {
-	color: var(--ctp-macchiato-text) !important;
+  color: #CAD3F5 !important;
 }
 
 /* TAGS */
 .tags .list-item-container {
-		display: inline-block;
-		line-height: 0 !important;
-		padding: 0 !important;
-		height: auto !important;
-		background-color: var(--ctp-macchiato-crust) !important;
+    display: inline-block;
+    line-height: 0 !important;
+    padding: 0 !important;
+    height: auto !important;
+    background-color: #181926 !important;
 }
 .tags .list-item-container:hover {
-	display: inline-block;
-	line-height: 0 !important;
-	padding: 0 !important;
-	height: auto !important;
-	background-color: var(--ctp-macchiato-overlay0) !important;
+  display: inline-block;
+  line-height: 0 !important;
+  padding: 0 !important;
+  height: auto !important;
+  background-color: #6E738D !important;
 }
 
 .tags .list-item-container a {
-	padding-left: 12px !important;
-	text-transform: initial;
-	color: var(--ctp-macchiato-text) !important;
-	font-weight: var(--regular);
+  padding-left: 12px !important;
+  text-transform: initial;
+  color: #CAD3F5 !important;
+  font-weight: var(--regular);
 }
 
 .tags .list-item-container a:focus {
-	color: var(--ctp-macchiato-text) !important;
-	background-color: var(--ctp-macchiato-base) !important;
+  color: #CAD3F5 !important;
+  background-color: #24273A !important;
 }
 
 .tags .list-item-container a:hover {
-	color: var(--ctp-macchiato-text) !important;
-	background-color: var(--ctp-macchiato-overlay0) !important;
+  color: #CAD3F5 !important;
+  background-color: #6E738D !important;
 }
 
 /* SYNCHRONIZATION */
 
 .sidebar > div:last-of-type {
-	background-color: none !important;
+  background-color: none !important;
 }
 
 .sidebar > div:last-of-type > button {
-	background-color: var(--ctp-macchiato-lavender) !important;
-	border: 0px !important;
-	text-transform: uppercase;
-	font-size: var(--font-size) !important;
+  background-color: #B7BDF8 !important;
+  border: 0px !important;
+  text-transform: uppercase;
+  font-size: var(--font-size) !important;
 }
 
 .sidebar > div:last-of-type > button:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 
 .sidebar > div:last-of-type > button > span {
-	color: var(--ctp-macchiato-crust) !important;
+  color: #181926 !important;
 }
 
 /*********************************************************************************
@@ -194,111 +168,111 @@ i.icon-notes {
 *********************************************************************************/
 
 .note-list {
-	background-color: var(--ctp-macchiato-mantle) !important;
-	border: none !important;
+  background-color: #1E2030 !important;
+  border: none !important;
 }
 
 /* Empty notelist */
 .cLdGCO, .cLdGCO > div {
-	background-color: var(--ctp-macchiato-mantle) !important;
+  background-color: #1E2030 !important;
 }
 
 /* Remove border - introduced in 1.3.7 */
 .rli-noteList div {
-	border: none !important;
+  border: none !important;
 }
 
 /* BUTTONS SEARCH, SORT NOTES, NEW NOTE AND NEW TASK */
 
 div[height="50"] {
-	background-color: var(--ctp-macchiato-mantle) !important;
+  background-color: #1E2030 !important;
 }
 
 div[height="50"] input {
-	border: none !important;
-	color: var(--ctp-macchiato-text) !important;
-	background-color: var(--ctp-macchiato-mantle) !important;
+  border: none !important;
+  color: #CAD3F5 !important;
+  background-color: #1E2030 !important;
 }
 
 div[height="50"] button {
-	background: transparent !important;
-	color: var(--ctp-macchiato-text) !important;
-	border: 0 !important;
+  background: transparent !important;
+  color: #CAD3F5 !important;
+  border: 0 !important;
 }
 
 div[height="50"] button:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 
 div[height="50"] button span {
-	color: var(--ctp-macchiato-text) !important;
+  color: #CAD3F5 !important;
 }
 
-.sc-hCPjZK.fJjcQe {
-	background-color: var(--ctp-macchiato-mantle) !important;
+.sc-hCPjZK.fJjcQe{
+  background-color: #1E2030 !important;
 }
 .new-note-todo-buttons > button {
-	background-color: var(--ctp-macchiato-lavender) !important;
-	border: none !important;
+  background-color: #B7BDF8 !important;
+  border: none !important;
 }
 .new-todo-button > span {
-	color: var(--ctp-macchiato-crust) !important;
+  color: #181926 !important;
 }
 
 .search-bar {
-	background-color: var(--ctp-macchiato-crust) !important;
+  background-color: #181926 !important;
 }
 
 .icon-search {
-	color: var(--ctp-macchiato-lavender) !important;
+  color: #B7BDF8 !important;
 }
 
 .sort-order-reverse-button {
-	background-color: var(--ctp-macchiato-crust) !important;
+  background-color: #181926 !important;
 }
 .sort-order-reverse-button {
-	background-color: var(--ctp-macchiato-crust) !important;
+  background-color: #181926 !important;
 }
 
 .fa-calendar-alt {
-	color: var(--ctp-macchiato-lavender) !important;
+  color: #B7BDF8 !important;
 }
 .fa-long-arrow-alt-up {
-	color: var(--ctp-macchiato-lavender) !important;
+  color: #B7BDF8 !important;
 }
 /* LIST OF NOTES */
 
 .note-list .list-item-container {
-	background-color: var(--ctp-macchiato-mantle) !important;
+  background-color: #1E2030 !important;
 }
 
 .note-list .list-item-container:hover {
-	background-color: var(--ctp-macchiato-overlay1) !important;
+  background-color: #8087A2 !important;
 }
 
 .item-list.note-list .list-item-container::before {
-	border: none !important;
+  border: none !important;
 }
 
 .note-list .list-item-container a {
-	text-transform: initial;
-	color: var(--ctp-macchiato-text) !important;
-	font-weight: var(--regular);
+  text-transform: initial;
+  color: #CAD3F5 !important;
+  font-weight: var(--regular);
 }
 
 .note-list .list-item-container a:focus {
-	color: var(--ctp-macchiato-text) !important;
-	background-color: var(--ctp-macchiato-base) !important;
+  color: #CAD3F5 !important;
+  background-color: #24273A !important;
 }
 
 .note-list .list-item-container a:hover {
-	color: var(--ctp-macchiato-text) !important;
+  color: #CAD3F5 !important;
 }
 
 /* Add "..." to notes with long titles */
 .item-list.note-list .list-item-container > a > span {
-	overflow: hidden;
-	text-overflow: ellipsis;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /*********************************************************************************
@@ -310,21 +284,21 @@ div[height="50"] button span {
 /* Title */
 /* Changes frequently with updates, need to keep tabs */
 .rli-editor .cCOtNv > input {
-	padding-top: 5px;
-	background-color: var(--ctp-macchiato-base) !important;
+  padding-top: 5px;
+  background-color: #24273A !important;
 }
 
 .title-input {
-  background-color: var(--ctp-macchiato-base) !important;
-  color: var(--ctp-macchiato-text) !important;
+  background-color: #24273A !important;
+  color: #CAD3F5 !important;
 }
 
 .editor-toolbar {
-	background-color: transparent !important;
+  background-color: transparent !important;
 }
 
 .editor-toolbar > div > a:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 
 /* Hide "Spell checker" button */
@@ -339,63 +313,64 @@ div[height="50"] button span {
 
 /* Hide the Toggle editors button */
 .editor-toolbar button[title="Toggle editors"] {
-	display: none !important;
+  display: none !important;
 }
 
 /* Breadcrumbs (In:...) - Used in tag listings */
 .cJOYJm {
-	background-color: var(--ctp-macchiato-lavender) !important;
-	margin: 0px !important;
-	padding: 5px !important;
-	font-size: var(--font-size) !important;
+  background-color: #B7BDF8 !important;
+  margin: 0px !important;
+  padding: 5px !important;
+  font-size: var(--font-size) !important;
 }
 
 .cJOYJm:hover {
-	opacity: var(--opacity-0-8);
+  opacity: var(--opacity-0-8);
 }
 
 /* CONTENT */
 /* Empty notebook */
 .rli-editor > div > div:empty {
-	background-color: var(--ctp-macchiato-base) !important;
+  background-color: #24273A !important;
 }
 
 /* Editor layout splitter */
 .rli-editor > div > div > div > div > div > div > div:last-of-type {
-	border-color: var(--ctp-macchiato-base) !important;
+  border-color: #24273A !important;
 }
+
 div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
-	background-color: var(--ctp-macchiato-mantle) !important;
-	color: var(--ctp-macchiato-text) !important;
+  background-color: #1E2030 !important;
+  color: #CAD3F5 !important;
 }
 
 /* NOTE SEARCH BAR */
 .note-search-bar, .note-search-bar > div > div {
-	background-color: var(--ctp-macchiato-base) !important;
-	width: 100%;
-	border: 0 !important;
+  background-color: #24273A !important;
+  width: 100%;
+  border: 0 !important;
 }
 
 .note-search-bar input {
-	border: 0 !important;
-	padding: 5px;
-	color: var(--ctp-macchiato-text) !important;
-	background-color: var(--ctp-macchiato-base) !important;
+  border: 0 !important;
+  padding: 5px;
+  color: #CAD3F5 !important;
+  background-color: #24273A !important;
 }
 
 /* TAGS */
 .tag-bar {
-	background-color: transparent !important;
+  background-color: transparent !important;
 }
 
 .tag-list > span {
-	color: var(--ctp-macchiato-lavender) !important;
-	background-color: var(--ctp-macchiato-crust) !important;
+  color: #B7BDF8 !important;
+  background-color: #181926 !important;
 }
 
 /* Hide "Click to add tags..."*/
 a[Title="Tags"] + div > span {
-	display: none !important;
+  display: none !important;
 }
 
 /*********************************************************************************
@@ -403,128 +378,128 @@ a[Title="Tags"] + div > span {
 *********************************************************************************/
 
 .cm-s-material-darker.CodeMirror {
-	background-color: var(--ctp-macchiato-base) !important;
-	color: var(--ctp-macchiato-text) !important;
+  background-color: #24273A !important;
+  color: #CAD3F5 !important;
 }
 
 /* Header */
 .cm-header {
-	color: var(--ctp-macchiato-lavender) !important;
+  color: #B7BDF8 !important;
 }
 
 /* Italics/Emphasis, Bold, BoldItalics */
 .cm-em, .cm-strong, .cm-strong.cm-em {
-	color: var(--ctp-macchiato-text) !important;
+  color: #CAD3F5 !important;
 }
 
 /* Lists (Bullet/number/todo) */
 .cm-variable-2, .cm-variable-3, .cm-keyword {
-	color: var(--ctp-macchiato-text) !important;
+  color: #CAD3F5 !important;
 }
 
 .cm-s-material-darker .cm-variable-2.cm-rm-list-token {
-	color: var(--ctp-macchiato-text) !important;
+  color: #CAD3F5 !important;
 }
 
 /* Links (link) */
 .cm-url {
-	color: var(--ctp-macchiato-rosewater) !important;
-	opacity: 1;
-	text-decoration: underline;
+  color: #F4DBD6 !important;
+  opacity: 1;
+  text-decoration: underline;
 }
 
 /* Links (text) */
 .cm-link-text {
-	color: var(--ctp-macchiato-rosewater) !important;
+  color: #F4DBD6 !important;
 }
 pre.CodeMirror-line {
-		color: var(--ctp-macchiato-text) !important;
-		background-color: none !important;
+    color: #CAD3F5 !important;
+    background-color: none !important;
 }
 /* Image link in editor */
 span.cm-string.cm-url.cm-overlay.cm-rm-link.cm-overlay.cm-rm-image {
-	color: var(--ctp-macchiato-lavender) !important;
+  color: #B7BDF8 !important;
 }
 /* Comment outside code block */
 pre.CodeMirror-line span.cm-comment {
-	color: var(--ctp-macchiato-overlay1) !important;
-	background-color: none !important;
-	border: 0 !important;
+  color: #8087A2 !important;
+  background-color: none !important;
+  border: 0 !important;
 }
 
 /* Codeblock selection colour */
 /* For some reason, the CodeMirror selection does not pick the colour correctly, left for now. */
 pre.CodeMirror-line span.CodeMirror-selectedtext {
-	/* background: var(--ctp-macchiato-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #5B6078 !important; */
+  background: #6B6B6B !important;
 }
 
 div[class^="cm-jn-code-block-background "]::selection {
-	background-color: var(--ctp-macchiato-base) !important;
-	border-color: var(--ctp-macchiato-base) !important;
+  background-color: #24273A !important;
+  border-color: #24273A !important;
 }
 
 pre.cm-jn-code-block.CodeMirror-line span.cm-comment.cm-jn-monospace.CodeMirror-selectedtext {
-	/* background: var(--ctp-macchiato-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #5B6078 !important; */
+  background: #6B6B6B !important;
 }
 pre.cm-jn-code-block.CodeMirror-line::selection {
-	/* background: var(--ctp-macchiato-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #5B6078 !important; */
+  background: #6B6B6B !important;
 }
 div.cm-jn-code-block-background.CodeMirror-linebackground::selection {
-	/* background: var(--ctp-macchiato-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #5B6078 !important; */
+  background: #6B6B6B !important;
 }
 pre.cm-jn-code-block.CodeMirror-line::selection span {
-	/* background: var(--ctp-macchiato-surface2) !important; */
-	background: #6B6B6B !important;
+  /* background: #5B6078 !important; */
+  background: #6B6B6B !important;
 }
 
 div.CodeMirror span.cm-comment.cm-jn-inline-code {
-	background-color: transparent !important;
-	padding-right: 0 !important;
-	padding-left: 0 !important;
+  background-color: transparent !important;
+  padding-right: 0 !important;
+  padding-left: 0 !important;
 }
 
 /* Code Block Text */
 div.CodeMirror span.cm-comment:not(.cm-jn-inline-code) {
-	color: var(--ctp-macchiato-text) !important;
-	background-color: transparent !important;
+  color: #CAD3F5 !important;
+  background-color: transparent !important;
 }
 
 /* Code block background */
 div.CodeMirror div.cm-jn-code-block-background {
-		background-color: var(--ctp-macchiato-mantle) !important;
+    background-color: #1E2030 !important;
 }
 
 /* Horizontal Line */
 .cm-hr {
-	color: var(--ctp-macchiato-overlay0) !important;
+  color: #6E738D !important;
 }
 
 /* Cursor colour */
 .CodeMirror-cursor {
-		border-left: 1px solid var(--ctp-macchiato-rosewater) !important;
-		border-right: none !important;
-		width: 0 !important;
+    border-left: 1px solid #F4DBD6 !important;
+    border-right: none !important;
+    width: 0 !important;
 }
 .cm-fat-cursor div.CodeMirror-cursor {
-		width: 10px !important;
-		border: 0 !important;
-		background: var(--ctp-macchiato-rosewater) !important;
+    width: 10px !important;
+    border: 0 !important;
+    background: #F4DBD6 !important;
 }
 .cm-fat-cursor div.CodeMirror-cursors {
-		z-index: 1 !important;
+    z-index: 1 !important;
 }
 .cm-fat-cursor-mark {
-		background-color: rgba(150, 205, 251, 0.5) !important;
+    background-color: rgba(125, 196, 228, 0.50) !important;
 }
 
 .cm-animate-fat-cursor {
-		width: auto !important;
-		border: 0;
-		background-color: var(--ctp-macchiato-rosewater) !important;
+    width: auto !important;
+    border: 0;
+    background-color: #F4DBD6 !important;
 }
 
 /* Rich Markdown Extra CSS Classes
@@ -532,42 +507,42 @@ Please opt in "Add additional CSS classes for enhanced customization" in plugin
 settings, see https://github.com/CalebJohn/joplin-rich-markdown#extra-css */
 
 .cm-header.cm-rm-header-token {
-	color: var(--ctp-macchiato-green) !important;
+  color: #A6DA95 !important;
 }
 
 .cm-strong.cm-rm-strong-token {
-	color: var(--ctp-macchiato-blue) !important;
+  color: #8AADF4 !important;
 }
 
 pre.cm-rm-blockquote.CodeMirror-line {
-	font-style: italic !important;
+  font-style: italic !important;
 }
 
 /* Command palette coloring */
 
 div.modal-dialog {
-	background-color: var(--ctp-macchiato-mantle) !important;
+  background-color: #1E2030 !important;
 }
 
 .modal-dialog > div > input {
-	background-color: var(--ctp-macchiato-crust) !important;
-	color: var(--ctp-macchiato-text) !important;
+  background-color: #181926 !important;
+  color: #CAD3F5 !important;
 }
 
 .modal-dialog > .item-list {
-	background-color: var(--ctp-macchiato-crust) !important;
-	color: var(--ctp-macchiato-text) !important;
+  background-color: #181926 !important;
+  color: #CAD3F5 !important;
 
 }
 
 .modal-dialog > .item-list div[class="selected"] {
-	background-color: var(--ctp-macchiato-surface2) !important;
+  background-color: #5B6078 !important;
 }
 
 .modal-dialog > .item-list div[class="selected"] > div {
-	color: var(--ctp-macchiato-text) !important;
+  color: #CAD3F5 !important;
 }
 
 .modal-dialog > .item-list > * {
-	color: var(--ctp-macchiato-text) !important;
+  color: #CAD3F5 !important;
 }

--- a/src/macchiato/userchrome.css
+++ b/src/macchiato/userchrome.css
@@ -57,7 +57,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-  min-width: 200px !important;
   background-color: #24273A !important;
 }
 

--- a/src/mocha/userchrome.css
+++ b/src/mocha/userchrome.css
@@ -57,7 +57,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-  min-width: 200px !important;
   background-color: #1E1E2E !important;
 }
 

--- a/src/mocha/userstyle.css
+++ b/src/mocha/userstyle.css
@@ -1,39 +1,12 @@
 /* Style for rendered Markdown */
-
 :root {
-  --ctp-mocha-rosewater: #f5e0dc;
-	--ctp-mocha-flamingo: #f2cdcd;
-	--ctp-mocha-pink: #f5c2e7;
-	--ctp-mocha-mauve: #cba6f7;
-	--ctp-mocha-red: #f38ba8;
-	--ctp-mocha-maroon: #eba0ac;
-	--ctp-mocha-peach: #fab387;
-	--ctp-mocha-yellow: #f9e2af;
-	--ctp-mocha-green: #a6e3a1;
-	--ctp-mocha-teal: #94e2d5;
-	--ctp-mocha-sky: #89dceb;
-	--ctp-mocha-sapphire: #74c7ec;
-	--ctp-mocha-blue: #87b0f9;
-	--ctp-mocha-lavender: #b4befe;
-	--ctp-mocha-text: #c6d0f5;
-	--ctp-mocha-subtext1: #b3bcdf;
-	--ctp-mocha-subtext0: #a1a8c9;
-	--ctp-mocha-overlay2: #8e95b3;
-	--ctp-mocha-overlay1: #7b819d;
-	--ctp-mocha-overlay0: #696d86;
-	--ctp-mocha-surface2: #565970;
-	--ctp-mocha-surface1: #43465a;
-	--ctp-mocha-surface0: #313244;
-	--ctp-mocha-base: #1e1e2e;
-	--ctp-mocha-mantle: #181825;
-	--ctp-mocha-crust: #11111b;
   --white: #D9E0EE;
   --black: #000000;
   --light: #C9CFFF;
   --lighter-grey: #C3BAC6;
   --light-grey: #988BA2;
 
-	--font-face: "Noto Sans", Arial, Helvetica, sans-serif;
+  --font-face: "Noto Sans", Arial, Helvetica, sans-serif;
   --font-mono: "Roboto Mono", Courier, monospace;
   --font-size: 13px;
   --icon-size: 16px;
@@ -47,27 +20,27 @@
 }
 
 #rendered-md, body, th, td {
-  background-color: var(--ctp-mocha-base) !important;
+  background-color: #1E1E2E !important;
   font-family: var(--font-face) !important;
 }
 
 p, ul, ol, li {
-  color: var(--ctp-mocha-text) !important;
+  color: #CDD6F4 !important;
 }
 
 strong {
-  color: var(--ctp-mocha-text) !important;
+  color: #CDD6F4 !important;
 }
 
 hr {
   border: none;
-  border-bottom: 1px solid var(--ctp-mocha-base) !important;
+  border-bottom: 1px solid #1E1E2E !important;
   margin: 2.5em 0 !important;
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar-thumb {
-  background-color: var(--ctp-mocha-base) !important;
+  background-color: #1E1E2E !important;
   border-radius: var(--scroll-radius) !important;
 }
 
@@ -76,7 +49,7 @@ hr {
 *********************************************************************************/
 
 h1 {
-  border-bottom: 1px solid var(--ctp-mocha-base) !important;
+  border-bottom: 1px solid #1E1E2E !important;
   font-weight: var(--bolder) !important;
 }
 
@@ -90,7 +63,7 @@ h2, h3, h4, h5, h6 {
 *********************************************************************************/
 
 a {
-  color: var(--ctp-mocha-rosewater) !important;
+  color: #F5E0DC !important;
   text-decoration: underline !important;
 }
 
@@ -100,7 +73,7 @@ a:hover {
 
 /* Joplin icon in Joplin link */
 .resource-icon {
-  background-color: var(--ctp-mocha-rosewater) !important;
+  background-color: #F5E0DC !important;
 }
 
 /*********************************************************************************
@@ -108,10 +81,10 @@ a:hover {
 *********************************************************************************/
 
 pre, .hljs {
-  background-color: var(--ctp-mocha-mantle) !important;
+  background-color: #181825 !important;
   font-family: var(--font-mono) !important;
   padding: 10px !important;
-  color: var(--ctp-mocha-text) !important;
+  color: #CDD6F4 !important;
   font-size: 14px !important;
   overflow: scroll !important;
 }
@@ -121,7 +94,7 @@ pre, .hljs {
   background-color: transparent !important;
   border: 0 !important;
   font-family: var(--font-mono) !important;
-  color: var(--ctp-mocha-yellow) !important;
+  color: #F9E2AF !important;
   font-size: 14px !important;
 }
 
@@ -130,13 +103,13 @@ pre, .hljs {
 *********************************************************************************/
 
 blockquote {
-  background-color: var(--ctp-mocha-surface0) !important;
+  background-color: #313244 !important;
   padding: 10px !important;
   color: var(--light) !important;
   font-size: 14px !important;
   font-style: italic !important;
   border: 0 !important;
-  border-left: 5px solid var(--ctp-mocha-mantle) !important;
+  border-left: 5px solid #181825 !important;
 }
 
 /*********************************************************************************
@@ -144,15 +117,15 @@ blockquote {
 *********************************************************************************/
 
 th {
-  border: 1px solid var(--ctp-mocha-text) !important;
-  color: var(--ctp-mocha-text) !important;
-  border-bottom: 1px solid var(--ctp-mocha-text) !important;
+  border: 1px solid #CDD6F4 !important;
+  color: #CDD6F4 !important;
+  border-bottom: 1px solid #CDD6F4 !important;
 }
 
 td {
-  border: 1px solid var(--ctp-mocha-text) !important;
-  color: var(--ctp-mocha-text) !important;
-  border-bottom: 1px solid var(--ctp-mocha-text) !important;
+  border: 1px solid #CDD6F4 !important;
+  color: #CDD6F4 !important;
+  border-bottom: 1px solid #CDD6F4 !important;
 }
 
 /*********************************************************************************
@@ -160,18 +133,18 @@ td {
 *********************************************************************************/
 
 ::selection {
-	background-color: var(--ctp-mocha-lavender) !important;
-  color: var(--ctp-mocha-crust) !important;
+  background-color: #B4BEFE !important;
+  color: #11111B !important;
 }
 
 mark, mark strong {
-  background: var(--ctp-mocha-yellow) !important;
-  color: var(--ctp-mocha-crust) !important;
+  background: #F9E2AF !important;
+  color: #11111B !important;
 }
 
 /* Highlighted searched item */
 mark[data-markjs] {
-  background-color: var(--ctp-mocha-lavender) !important;
+  background-color: #B4BEFE !important;
 }
 
 /*********************************************************************************
@@ -189,8 +162,8 @@ mark[data-markjs] {
 /* Container for spoiler title */
 #spoiler-block-title {
   font-family: var(--font-face) !important;
-  color: var(--ctp-mocha-text) !important;
-  background-color: var(--ctp-mocha-mantle) !important;
+  color: #CDD6F4 !important;
+  background-color: #181825 !important;
   border-radius: 0px;
 }
 
@@ -198,17 +171,17 @@ mark[data-markjs] {
 #spoiler-block-body {
   font-family: var(--font-face) !important;
   color: var(--light) !important;
-  background-color: var(--ctp-mocha-mantle) !important;
+  background-color: #181825 !important;
   border-radius: 0px;
 }
 
 /* Styling of the spoiler block body */
 .summary-content {
-  background-color: var(--ctp-mocha-mantle) !important;
+  background-color: #181825 !important;
 }
 
 .summary-title:before {
-  color: var(--ctp-mocha-lavender) !important;
+  color: #B4BEFE !important;
 }
 
 /*********************************************************************************
@@ -226,22 +199,21 @@ mark[data-markjs] {
   p, ul, ol, li {
     color: var(--black) !important;
   }
-  
+
   strong {
     color: var(--black) !important;
   }
-
-th {
+  th {
   border: 1px solid var(--black) !important;
   color: var(--black) !important;
   border-bottom: 1px solid var(--black) !important;
-}
+  }
 
-td {
+  td {
   border: 1px solid var(--black) !important;
   color: var(--black) !important;
   border-bottom: 1px solid var(--black) !important;
-}
+  }
 
   h1 {
     border-bottom: 1px solid var(--black) !important;
@@ -260,7 +232,7 @@ td {
   }
 
   a {
-    color: var(--ctp-mocha-red) !important;
+    color: #F38BA8 !important;
     text-decoration: underline !important;
   }
 
@@ -269,8 +241,7 @@ td {
   background-color: #F8F8F8 !important;
   border: 0 !important;
   font-family: var(--font-mono) !important;
-  /* color: var(--ctp-mocha-yellow) !important; */
-  /* color: # !important; */
+  /* color: #F9E2AF !important; */
   font-size: 14px !important;
 }
 
@@ -278,7 +249,7 @@ pre, .hljs {
   background-color: #F8F8F8 !important;
   font-family: var(--font-mono) !important;
   padding: 10px !important;
-  color: var(--ctp-mocha-crust) !important;
+  color: #11111B !important;
   font-size: 14px !important;
   overflow: scroll !important;
 }
@@ -286,7 +257,7 @@ pre, .hljs {
 blockquote {
   background-color: #F8F8F8 !important;
   padding: 10px !important;
-  color: var(--ctp-mocha-crust) !important;
+  color: #11111B !important;
   font-size: 14px !important;
   font-style: italic !important;
   border: 0 !important;

--- a/templates/userchrome.tera
+++ b/templates/userchrome.tera
@@ -65,7 +65,6 @@ html, body {
 
 /* General panel style */
 .resizableLayoutItem > div {
-  min-width: 200px !important;
   background-color: {{ base.hex }} !important;
 }
 

--- a/templates/userchrome.tera
+++ b/templates/userchrome.tera
@@ -1,3 +1,11 @@
+---
+whiskers:
+  version: 2.4.0
+  matrix:
+    - flavor
+  filename: "src/{{ flavor.identifier }}/userchrome.css"
+  hex_format: "#{{R}}{{G}}{{B}}"
+---
 /* Original theme at https://github.com/stysebae/joplin-vsc-material-theme, modified for Catppuccin. */
 /* For styling the entire Joplin app (except the rendered Markdown, which is defined in `userstyle.css`) */
 
@@ -21,7 +29,7 @@
 }
 
 html, body {
-  background-color: #1E1E2E !important;
+  background-color: {{ base.hex }} !important;
   font-size: var(--font-size) !important;
   font-weight: var(--regular) !important;
   color: var(--light) !important;
@@ -31,7 +39,7 @@ html, body {
     background: #6B6B6B !important;
 }
 .rli-root {
-  background-color: #1E1E2E !important;
+  background-color: {{ base.hex }} !important;
 }
 
 /* Icons */
@@ -42,12 +50,12 @@ html, body {
 }
 
 ::placeholder {
-  color: #B4BEFE !important;
+  color: {{ lavender.hex }} !important;
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar-thumb {
-  background-color: #313244 !important;
+  background-color: {{ surface0.hex }} !important;
   border-radius: var(--scroll-radius) !important;
 }
 
@@ -58,7 +66,7 @@ html, body {
 /* General panel style */
 .resizableLayoutItem > div {
   min-width: 200px !important;
-  background-color: #1E1E2E !important;
+  background-color: {{ base.hex }} !important;
 }
 
 /*********************************************************************************
@@ -66,7 +74,7 @@ html, body {
 *********************************************************************************/
 
 .sidebar {
-  background-color: #11111B !important;
+  background-color: {{ crust.hex }} !important;
   text-transform: uppercase;
   font-weight: var(--bolder);
 }
@@ -81,32 +89,32 @@ i.icon-notes {
 
 /* "Add new notebook" button */
 .sidebar > div > div > button span {
-  color: #B4BEFE !important;
+  color: {{ lavender.hex }} !important;
 }
 
 .sidebar > div > div > button:hover {
   opacity: var(--opacity-0-8);
 }
 .folders .list-item-container {
-    background-color: #11111B !important;
+    background-color: {{ crust.hex }} !important;
 }
 .folders .list-item-container:hover {
-  background-color: #6C7086 !important;
+  background-color: {{ overlay0.hex }} !important;
 }
 
 .folders .list-item-container a {
   text-transform: initial;
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
   font-weight: var(--regular);
 }
 
 .folders .list-item-container a:focus {
-  color: #CDD6F4 !important;
-  background-color: #1E1E2E !important;
+  color: {{ text.hex }} !important;
+  background-color: {{ base.hex }} !important;
 }
 
 .folders .list-item-container a:hover {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
 }
 
 /* TAGS */
@@ -115,31 +123,31 @@ i.icon-notes {
     line-height: 0 !important;
     padding: 0 !important;
     height: auto !important;
-    background-color: #11111B !important;
+    background-color: {{ crust.hex }} !important;
 }
 .tags .list-item-container:hover {
   display: inline-block;
   line-height: 0 !important;
   padding: 0 !important;
   height: auto !important;
-  background-color: #6C7086 !important;
+  background-color: {{ overlay0.hex }} !important;
 }
 
 .tags .list-item-container a {
   padding-left: 12px !important;
   text-transform: initial;
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
   font-weight: var(--regular);
 }
 
 .tags .list-item-container a:focus {
-  color: #CDD6F4 !important;
-  background-color: #1E1E2E !important;
+  color: {{ text.hex }} !important;
+  background-color: {{ base.hex }} !important;
 }
 
 .tags .list-item-container a:hover {
-  color: #CDD6F4 !important;
-  background-color: #6C7086 !important;
+  color: {{ text.hex }} !important;
+  background-color: {{ overlay0.hex }} !important;
 }
 
 /* SYNCHRONIZATION */
@@ -149,7 +157,7 @@ i.icon-notes {
 }
 
 .sidebar > div:last-of-type > button {
-  background-color: #B4BEFE !important;
+  background-color: {{ lavender.hex }} !important;
   border: 0px !important;
   text-transform: uppercase;
   font-size: var(--font-size) !important;
@@ -160,7 +168,7 @@ i.icon-notes {
 }
 
 .sidebar > div:last-of-type > button > span {
-  color: #11111B !important;
+  color: {{ crust.hex }} !important;
 }
 
 /*********************************************************************************
@@ -168,13 +176,13 @@ i.icon-notes {
 *********************************************************************************/
 
 .note-list {
-  background-color: #181825 !important;
+  background-color: {{ mantle.hex }} !important;
   border: none !important;
 }
 
 /* Empty notelist */
 .cLdGCO, .cLdGCO > div {
-  background-color: #181825 !important;
+  background-color: {{ mantle.hex }} !important;
 }
 
 /* Remove border - introduced in 1.3.7 */
@@ -185,18 +193,18 @@ i.icon-notes {
 /* BUTTONS SEARCH, SORT NOTES, NEW NOTE AND NEW TASK */
 
 div[height="50"] {
-  background-color: #181825 !important;
+  background-color: {{ mantle.hex }} !important;
 }
 
 div[height="50"] input {
   border: none !important;
-  color: #CDD6F4 !important;
-  background-color: #181825 !important;
+  color: {{ text.hex }} !important;
+  background-color: {{ mantle.hex }} !important;
 }
 
 div[height="50"] button {
   background: transparent !important;
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
   border: 0 !important;
 }
 
@@ -205,49 +213,49 @@ div[height="50"] button:hover {
 }
 
 div[height="50"] button span {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
 }
 
 .sc-hCPjZK.fJjcQe{
-  background-color: #181825 !important;
+  background-color: {{ mantle.hex }} !important;
 }
 .new-note-todo-buttons > button {
-  background-color: #B4BEFE !important;
+  background-color: {{ lavender.hex }} !important;
   border: none !important;
 }
 .new-todo-button > span {
-  color: #11111B !important;
+  color: {{ crust.hex }} !important;
 }
 
 .search-bar {
-  background-color: #11111B !important;
+  background-color: {{ crust.hex }} !important;
 }
 
 .icon-search {
-  color: #B4BEFE !important;
+  color: {{ lavender.hex }} !important;
 }
 
 .sort-order-reverse-button {
-  background-color: #11111B !important;
+  background-color: {{ crust.hex }} !important;
 }
 .sort-order-reverse-button {
-  background-color: #11111B !important;
+  background-color: {{ crust.hex }} !important;
 }
 
 .fa-calendar-alt {
-  color: #B4BEFE !important;
+  color: {{ lavender.hex }} !important;
 }
 .fa-long-arrow-alt-up {
-  color: #B4BEFE !important;
+  color: {{ lavender.hex }} !important;
 }
 /* LIST OF NOTES */
 
 .note-list .list-item-container {
-  background-color: #181825 !important;
+  background-color: {{ mantle.hex }} !important;
 }
 
 .note-list .list-item-container:hover {
-  background-color: #7F849C !important;
+  background-color: {{ overlay1.hex }} !important;
 }
 
 .item-list.note-list .list-item-container::before {
@@ -256,17 +264,17 @@ div[height="50"] button span {
 
 .note-list .list-item-container a {
   text-transform: initial;
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
   font-weight: var(--regular);
 }
 
 .note-list .list-item-container a:focus {
-  color: #CDD6F4 !important;
-  background-color: #1E1E2E !important;
+  color: {{ text.hex }} !important;
+  background-color: {{ base.hex }} !important;
 }
 
 .note-list .list-item-container a:hover {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
 }
 
 /* Add "..." to notes with long titles */
@@ -285,12 +293,12 @@ div[height="50"] button span {
 /* Changes frequently with updates, need to keep tabs */
 .rli-editor .cCOtNv > input {
   padding-top: 5px;
-  background-color: #1E1E2E !important;
+  background-color: {{ base.hex }} !important;
 }
 
 .title-input {
-  background-color: #1E1E2E !important;
-  color: #CDD6F4 !important;
+  background-color: {{ base.hex }} !important;
+  color: {{ text.hex }} !important;
 }
 
 .editor-toolbar {
@@ -318,7 +326,7 @@ div[height="50"] button span {
 
 /* Breadcrumbs (In:...) - Used in tag listings */
 .cJOYJm {
-  background-color: #B4BEFE !important;
+  background-color: {{ lavender.hex }} !important;
   margin: 0px !important;
   padding: 5px !important;
   font-size: var(--font-size) !important;
@@ -331,22 +339,22 @@ div[height="50"] button span {
 /* CONTENT */
 /* Empty notebook */
 .rli-editor > div > div:empty {
-  background-color: #1E1E2E !important;
+  background-color: {{ base.hex }} !important;
 }
 
 /* Editor layout splitter */
 .rli-editor > div > div > div > div > div > div > div:last-of-type {
-  border-color: #1E1E2E !important;
+  border-color: {{ base.hex }} !important;
 }
 
 div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
-  background-color: #181825 !important;
-  color: #CDD6F4 !important;
+  background-color: {{ mantle.hex }} !important;
+  color: {{ text.hex }} !important;
 }
 
 /* NOTE SEARCH BAR */
 .note-search-bar, .note-search-bar > div > div {
-  background-color: #1E1E2E !important;
+  background-color: {{ base.hex }} !important;
   width: 100%;
   border: 0 !important;
 }
@@ -354,8 +362,8 @@ div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
 .note-search-bar input {
   border: 0 !important;
   padding: 5px;
-  color: #CDD6F4 !important;
-  background-color: #1E1E2E !important;
+  color: {{ text.hex }} !important;
+  background-color: {{ base.hex }} !important;
 }
 
 /* TAGS */
@@ -364,8 +372,8 @@ div.sc-AxirZ.hagDvo, div.sc-AxirZ.hagDvo > div {
 }
 
 .tag-list > span {
-  color: #B4BEFE !important;
-  background-color: #11111B !important;
+  color: {{ lavender.hex }} !important;
+  background-color: {{ crust.hex }} !important;
 }
 
 /* Hide "Click to add tags..."*/
@@ -378,51 +386,51 @@ a[Title="Tags"] + div > span {
 *********************************************************************************/
 
 .cm-s-material-darker.CodeMirror {
-  background-color: #1E1E2E !important;
-  color: #CDD6F4 !important;
+  background-color: {{ base.hex }} !important;
+  color: {{ text.hex }} !important;
 }
 
 /* Header */
 .cm-header {
-  color: #B4BEFE !important;
+  color: {{ lavender.hex }} !important;
 }
 
 /* Italics/Emphasis, Bold, BoldItalics */
 .cm-em, .cm-strong, .cm-strong.cm-em {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
 }
 
 /* Lists (Bullet/number/todo) */
 .cm-variable-2, .cm-variable-3, .cm-keyword {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
 }
 
 .cm-s-material-darker .cm-variable-2.cm-rm-list-token {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
 }
 
 /* Links (link) */
 .cm-url {
-  color: #F5E0DC !important;
+  color: {{ rosewater.hex }} !important;
   opacity: 1;
   text-decoration: underline;
 }
 
 /* Links (text) */
 .cm-link-text {
-  color: #F5E0DC !important;
+  color: {{ rosewater.hex }} !important;
 }
 pre.CodeMirror-line {
-    color: #CDD6F4 !important;
+    color: {{ text.hex }} !important;
     background-color: none !important;
 }
 /* Image link in editor */
 span.cm-string.cm-url.cm-overlay.cm-rm-link.cm-overlay.cm-rm-image {
-  color: #B4BEFE !important;
+  color: {{ lavender.hex }} !important;
 }
 /* Comment outside code block */
 pre.CodeMirror-line span.cm-comment {
-  color: #7F849C !important;
+  color: {{ overlay1.hex }} !important;
   background-color: none !important;
   border: 0 !important;
 }
@@ -430,29 +438,29 @@ pre.CodeMirror-line span.cm-comment {
 /* Codeblock selection colour */
 /* For some reason, the CodeMirror selection does not pick the colour correctly, left for now. */
 pre.CodeMirror-line span.CodeMirror-selectedtext {
-  /* background: #585B70 !important; */
+  /* background: {{ surface2.hex }} !important; */
   background: #6B6B6B !important;
 }
 
 div[class^="cm-jn-code-block-background "]::selection {
-  background-color: #1E1E2E !important;
-  border-color: #1E1E2E !important;
+  background-color: {{ base.hex }} !important;
+  border-color: {{ base.hex }} !important;
 }
 
 pre.cm-jn-code-block.CodeMirror-line span.cm-comment.cm-jn-monospace.CodeMirror-selectedtext {
-  /* background: #585B70 !important; */
+  /* background: {{ surface2.hex }} !important; */
   background: #6B6B6B !important;
 }
 pre.cm-jn-code-block.CodeMirror-line::selection {
-  /* background: #585B70 !important; */
+  /* background: {{ surface2.hex }} !important; */
   background: #6B6B6B !important;
 }
 div.cm-jn-code-block-background.CodeMirror-linebackground::selection {
-  /* background: #585B70 !important; */
+  /* background: {{ surface2.hex }} !important; */
   background: #6B6B6B !important;
 }
 pre.cm-jn-code-block.CodeMirror-line::selection span {
-  /* background: #585B70 !important; */
+  /* background: {{ surface2.hex }} !important; */
   background: #6B6B6B !important;
 }
 
@@ -464,42 +472,42 @@ div.CodeMirror span.cm-comment.cm-jn-inline-code {
 
 /* Code Block Text */
 div.CodeMirror span.cm-comment:not(.cm-jn-inline-code) {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
   background-color: transparent !important;
 }
 
 /* Code block background */
 div.CodeMirror div.cm-jn-code-block-background {
-    background-color: #181825 !important;
+    background-color: {{ mantle.hex }} !important;
 }
 
 /* Horizontal Line */
 .cm-hr {
-  color: #6C7086 !important;
+  color: {{ overlay0.hex }} !important;
 }
 
 /* Cursor colour */
 .CodeMirror-cursor {
-    border-left: 1px solid #F5E0DC !important;
+    border-left: 1px solid {{ rosewater.hex }} !important;
     border-right: none !important;
     width: 0 !important;
 }
 .cm-fat-cursor div.CodeMirror-cursor {
     width: 10px !important;
     border: 0 !important;
-    background: #F5E0DC !important;
+    background: {{ rosewater.hex }} !important;
 }
 .cm-fat-cursor div.CodeMirror-cursors {
     z-index: 1 !important;
 }
 .cm-fat-cursor-mark {
-    background-color: rgba(116, 199, 236, 0.50) !important;
+    background-color: {{ sapphire | mod(opacity=0.5) | css_rgba }} !important;
 }
 
 .cm-animate-fat-cursor {
     width: auto !important;
     border: 0;
-    background-color: #F5E0DC !important;
+    background-color: {{ rosewater.hex }} !important;
 }
 
 /* Rich Markdown Extra CSS Classes
@@ -507,11 +515,11 @@ Please opt in "Add additional CSS classes for enhanced customization" in plugin
 settings, see https://github.com/CalebJohn/joplin-rich-markdown#extra-css */
 
 .cm-header.cm-rm-header-token {
-  color: #A6E3A1 !important;
+  color: {{ green.hex }} !important;
 }
 
 .cm-strong.cm-rm-strong-token {
-  color: #89B4FA !important;
+  color: {{ blue.hex }} !important;
 }
 
 pre.cm-rm-blockquote.CodeMirror-line {
@@ -521,28 +529,28 @@ pre.cm-rm-blockquote.CodeMirror-line {
 /* Command palette coloring */
 
 div.modal-dialog {
-  background-color: #181825 !important;
+  background-color: {{ mantle.hex }} !important;
 }
 
 .modal-dialog > div > input {
-  background-color: #11111B !important;
-  color: #CDD6F4 !important;
+  background-color: {{ crust.hex }} !important;
+  color: {{ text.hex }} !important;
 }
 
 .modal-dialog > .item-list {
-  background-color: #11111B !important;
-  color: #CDD6F4 !important;
+  background-color: {{ crust.hex }} !important;
+  color: {{ text.hex }} !important;
 
 }
 
 .modal-dialog > .item-list div[class="selected"] {
-  background-color: #585B70 !important;
+  background-color: {{ surface2.hex }} !important;
 }
 
 .modal-dialog > .item-list div[class="selected"] > div {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
 }
 
 .modal-dialog > .item-list > * {
-  color: #CDD6F4 !important;
+  color: {{ text.hex }} !important;
 }

--- a/templates/userstyle.tera
+++ b/templates/userstyle.tera
@@ -1,3 +1,11 @@
+---
+whiskers:
+  version: 2.4.0
+  matrix:
+    - flavor
+  filename: "src/{{ flavor.identifier }}/userstyle.css"
+  hex_format: "#{{R}}{{G}}{{B}}"
+---
 /* Style for rendered Markdown */
 :root {
   --white: #D9E0EE;
@@ -20,27 +28,27 @@
 }
 
 #rendered-md, body, th, td {
-  background-color: #24273A !important;
+  background-color: {{ base.hex }} !important;
   font-family: var(--font-face) !important;
 }
 
 p, ul, ol, li {
-  color: #CAD3F5 !important;
+  color: {{ text.hex }} !important;
 }
 
 strong {
-  color: #CAD3F5 !important;
+  color: {{ text.hex }} !important;
 }
 
 hr {
   border: none;
-  border-bottom: 1px solid #24273A !important;
+  border-bottom: 1px solid {{ base.hex }} !important;
   margin: 2.5em 0 !important;
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar-thumb {
-  background-color: #24273A !important;
+  background-color: {{ base.hex }} !important;
   border-radius: var(--scroll-radius) !important;
 }
 
@@ -49,7 +57,7 @@ hr {
 *********************************************************************************/
 
 h1 {
-  border-bottom: 1px solid #24273A !important;
+  border-bottom: 1px solid {{ base.hex }} !important;
   font-weight: var(--bolder) !important;
 }
 
@@ -63,7 +71,7 @@ h2, h3, h4, h5, h6 {
 *********************************************************************************/
 
 a {
-  color: #F4DBD6 !important;
+  color: {{ rosewater.hex }} !important;
   text-decoration: underline !important;
 }
 
@@ -73,7 +81,7 @@ a:hover {
 
 /* Joplin icon in Joplin link */
 .resource-icon {
-  background-color: #F4DBD6 !important;
+  background-color: {{ rosewater.hex }} !important;
 }
 
 /*********************************************************************************
@@ -81,10 +89,10 @@ a:hover {
 *********************************************************************************/
 
 pre, .hljs {
-  background-color: #1E2030 !important;
+  background-color: {{ mantle.hex }} !important;
   font-family: var(--font-mono) !important;
   padding: 10px !important;
-  color: #CAD3F5 !important;
+  color: {{ text.hex }} !important;
   font-size: 14px !important;
   overflow: scroll !important;
 }
@@ -94,7 +102,7 @@ pre, .hljs {
   background-color: transparent !important;
   border: 0 !important;
   font-family: var(--font-mono) !important;
-  color: #EED49F !important;
+  color: {{ yellow.hex }} !important;
   font-size: 14px !important;
 }
 
@@ -103,13 +111,13 @@ pre, .hljs {
 *********************************************************************************/
 
 blockquote {
-  background-color: #363A4F !important;
+  background-color: {{ surface0.hex }} !important;
   padding: 10px !important;
   color: var(--light) !important;
   font-size: 14px !important;
   font-style: italic !important;
   border: 0 !important;
-  border-left: 5px solid #1E2030 !important;
+  border-left: 5px solid {{ mantle.hex }} !important;
 }
 
 /*********************************************************************************
@@ -117,15 +125,15 @@ blockquote {
 *********************************************************************************/
 
 th {
-  border: 1px solid #CAD3F5 !important;
-  color: #CAD3F5 !important;
-  border-bottom: 1px solid #CAD3F5 !important;
+  border: 1px solid {{ text.hex }} !important;
+  color: {{ text.hex }} !important;
+  border-bottom: 1px solid {{ text.hex }} !important;
 }
 
 td {
-  border: 1px solid #CAD3F5 !important;
-  color: #CAD3F5 !important;
-  border-bottom: 1px solid #CAD3F5 !important;
+  border: 1px solid {{ text.hex }} !important;
+  color: {{ text.hex }} !important;
+  border-bottom: 1px solid {{ text.hex }} !important;
 }
 
 /*********************************************************************************
@@ -133,18 +141,18 @@ td {
 *********************************************************************************/
 
 ::selection {
-  background-color: #B7BDF8 !important;
-  color: #181926 !important;
+  background-color: {{ lavender.hex }} !important;
+  color: {{ crust.hex }} !important;
 }
 
 mark, mark strong {
-  background: #EED49F !important;
-  color: #181926 !important;
+  background: {{ yellow.hex }} !important;
+  color: {{ crust.hex }} !important;
 }
 
 /* Highlighted searched item */
 mark[data-markjs] {
-  background-color: #B7BDF8 !important;
+  background-color: {{ lavender.hex }} !important;
 }
 
 /*********************************************************************************
@@ -162,8 +170,8 @@ mark[data-markjs] {
 /* Container for spoiler title */
 #spoiler-block-title {
   font-family: var(--font-face) !important;
-  color: #CAD3F5 !important;
-  background-color: #1E2030 !important;
+  color: {{ text.hex }} !important;
+  background-color: {{ mantle.hex }} !important;
   border-radius: 0px;
 }
 
@@ -171,17 +179,17 @@ mark[data-markjs] {
 #spoiler-block-body {
   font-family: var(--font-face) !important;
   color: var(--light) !important;
-  background-color: #1E2030 !important;
+  background-color: {{ mantle.hex }} !important;
   border-radius: 0px;
 }
 
 /* Styling of the spoiler block body */
 .summary-content {
-  background-color: #1E2030 !important;
+  background-color: {{ mantle.hex }} !important;
 }
 
 .summary-title:before {
-  color: #B7BDF8 !important;
+  color: {{ lavender.hex }} !important;
 }
 
 /*********************************************************************************
@@ -232,7 +240,7 @@ mark[data-markjs] {
   }
 
   a {
-    color: #ED8796 !important;
+    color: {{ red.hex }} !important;
     text-decoration: underline !important;
   }
 
@@ -241,7 +249,7 @@ mark[data-markjs] {
   background-color: #F8F8F8 !important;
   border: 0 !important;
   font-family: var(--font-mono) !important;
-  /* color: #EED49F !important; */
+  /* color: {{ yellow.hex }} !important; */
   font-size: 14px !important;
 }
 
@@ -249,7 +257,7 @@ pre, .hljs {
   background-color: #F8F8F8 !important;
   font-family: var(--font-mono) !important;
   padding: 10px !important;
-  color: #181926 !important;
+  color: {{ crust.hex }} !important;
   font-size: 14px !important;
   overflow: scroll !important;
 }
@@ -257,7 +265,7 @@ pre, .hljs {
 blockquote {
   background-color: #F8F8F8 !important;
   padding: 10px !important;
-  color: #181926 !important;
+  color: {{ crust.hex }} !important;
   font-size: 14px !important;
   font-style: italic !important;
   border: 0 !important;


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's in-house templating tool, to build the themes. Instead editing the `.css` files individually, edit the `.tera` template files in `templates/` and then run `just build` to build the output themes. You will need Whiskers (linked above) and [Just](https://github.com/casey/just) installed.
