### PR TITLE
Fix missing colors in classes, outdated IDs, add item list theming

### DIFF
--- a/src/frappe/userchrome.css
+++ b/src/frappe/userchrome.css
@@ -233,8 +233,8 @@ div[height="50"] button span {
 	color: var(--ctp-frappe-text) !important;
 }
 
-.sc-hCPjZK.fJjcQe{
-	background-color: var(--ctp-frappe-mantle) !important;
+.sc-dtInlm.dUXxSp {
+  background-color: var(--ctp-frappe-mantle) !important;
 }
 .new-note-todo-buttons > button {
 	background-color: var(--ctp-frappe-lavender) !important;
@@ -275,8 +275,16 @@ div[height="50"] button span {
 	background-color: var(--ctp-frappe-overlay1) !important;
 }
 
+.note-list-item:hover {
+  background-color: var(--ctp-frappe-overlay0) !important;
+}
+
 .item-list.note-list .list-item-container::before {
 	border: none !important;
+}
+
+.note-list-item::before{
+  border: none !important;
 }
 
 .note-list .list-item-container a {
@@ -290,8 +298,20 @@ div[height="50"] button span {
 	background-color: var(--ctp-frappe-base) !important;
 }
 
+.list-item-wrapper.-selected {
+  background-color: var(--ctp-frappe-base) !important;
+}
+
+.note-list-item > .content.-selected {
+  background-color: var(--ctp-frappe-surface2) !important;
+}
+
 .note-list .list-item-container a:hover {
 	color: var(--ctp-frappe-text) !important;
+}
+
+.list-item-wrapper.-highlight-on-hover:hover {
+  background-color: var(--ctp-frappe-surface1);
 }
 
 /* Add "..." to notes with long titles */

--- a/src/frappe/userchrome.css
+++ b/src/frappe/userchrome.css
@@ -412,6 +412,11 @@ a[Title="Tags"] + div > span {
 	color: var(--ctp-frappe-lavender) !important;
 }
 
+/* Markdown editor */
+.cm-editor{
+    background-color: var(--ctp-frappe-base) !important
+}
+
 /* Italics/Emphasis, Bold, BoldItalics */
 .cm-em, .cm-strong, .cm-strong.cm-em {
 	color: var(--ctp-frappe-text) !important;

--- a/src/latte/userchrome.css
+++ b/src/latte/userchrome.css
@@ -447,6 +447,11 @@ a[Title="Tags"] + div > span {
   color: var(--ctp-latte-lavender) !important;
 }
 
+/* Markdown editor */
+.cm-editor{
+    background-color: var(--ctp-latte-base) !important
+}
+
 /* Italics/Emphasis, Bold, BoldItalics */
 .cm-em, .cm-strong, .cm-strong.cm-em {
   color: var(--ctp-latte-text) !important;

--- a/src/latte/userchrome.css
+++ b/src/latte/userchrome.css
@@ -260,7 +260,7 @@ div[height="50"] button span {
   background-color: var(--ctp-latte-mantle) !important;
 }
 
-.sc-hCPjZK.fJjcQe {
+.sc-dtInlm.dUXxSp {
   background-color: var(--ctp-latte-mantle) !important;
 }
 .new-note-todo-buttons > button {
@@ -303,7 +303,15 @@ div[height="50"] button span {
   background-color: var(--ctp-latte-overlay1) !important;
 }
 
+.note-list-item:hover {
+  background-color: var(--ctp-latte-overlay0) !important;
+}
+
 .item-list.note-list .list-item-container::before {
+  border: none !important;
+}
+
+.note-list-item::before{
   border: none !important;
 }
 
@@ -318,8 +326,20 @@ div[height="50"] button span {
   background-color: var(--ctp-latte-base) !important;
 }
 
+.list-item-wrapper.-selected {
+  background-color: var(--ctp-latte-base) !important;
+}
+
+.note-list-item > .content.-selected {
+  background-color: var(--ctp-latte-surface2) !important;
+}
+
 .note-list .list-item-container a:hover {
   color: var(--ctp-latte-text) !important;
+}
+
+.list-item-wrapper.-highlight-on-hover:hover {
+  background-color: var(--ctp-latte-surface1);
 }
 
 /* Add "..." to notes with long titles */

--- a/src/macchiato/userchrome.css
+++ b/src/macchiato/userchrome.css
@@ -233,8 +233,8 @@ div[height="50"] button span {
 	color: var(--ctp-macchiato-text) !important;
 }
 
-.sc-hCPjZK.fJjcQe {
-	background-color: var(--ctp-macchiato-mantle) !important;
+.sc-dtInlm.dUXxSp {
+  background-color: var(--ctp-macchiato-mantle) !important;
 }
 .new-note-todo-buttons > button {
 	background-color: var(--ctp-macchiato-lavender) !important;
@@ -275,8 +275,16 @@ div[height="50"] button span {
 	background-color: var(--ctp-macchiato-overlay1) !important;
 }
 
+.note-list-item:hover {
+  background-color: var(--ctp-macchiato-overlay0) !important;
+}
+
 .item-list.note-list .list-item-container::before {
 	border: none !important;
+}
+
+.note-list-item::before{
+  border: none !important;
 }
 
 .note-list .list-item-container a {
@@ -290,8 +298,20 @@ div[height="50"] button span {
 	background-color: var(--ctp-macchiato-base) !important;
 }
 
+.list-item-wrapper.-selected {
+  background-color: var(--ctp-macchiato-base) !important;
+}
+
+.note-list-item > .content.-selected {
+  background-color: var(--ctp-macchiato-surface2) !important;
+}
+
 .note-list .list-item-container a:hover {
 	color: var(--ctp-macchiato-text) !important;
+}
+
+.list-item-wrapper.-highlight-on-hover:hover {
+  background-color: var(--ctp-macchiato-surface1);
 }
 
 /* Add "..." to notes with long titles */

--- a/src/macchiato/userchrome.css
+++ b/src/macchiato/userchrome.css
@@ -411,6 +411,11 @@ a[Title="Tags"] + div > span {
 	color: var(--ctp-macchiato-lavender) !important;
 }
 
+/* Markdown editor */
+.cm-editor{
+    background-color: var(--ctp-macchiato-base) !important
+}
+
 /* Italics/Emphasis, Bold, BoldItalics */
 .cm-em, .cm-strong, .cm-strong.cm-em {
 	color: var(--ctp-macchiato-text) !important;

--- a/src/mocha/userchrome.css
+++ b/src/mocha/userchrome.css
@@ -410,6 +410,11 @@ a[Title="Tags"] + div > span {
   color: var(--ctp-mocha-lavender) !important;
 }
 
+/* Markdown editor */
+.cm-editor{
+    background-color: var(--ctp-mocha-base) !important
+}
+
 /* Italics/Emphasis, Bold, BoldItalics */
 .cm-em, .cm-strong, .cm-strong.cm-em {
   color: var(--ctp-mocha-text) !important;

--- a/src/mocha/userchrome.css
+++ b/src/mocha/userchrome.css
@@ -233,7 +233,7 @@ div[height="50"] button span {
   color: var(--ctp-mocha-text) !important;
 }
 
-.sc-hCPjZK.fJjcQe {
+.sc-dtInlm.dUXxSp {
   background-color: var(--ctp-mocha-mantle) !important;
 }
 .new-note-todo-buttons > button {
@@ -275,7 +275,15 @@ div[height="50"] button span {
   background-color: var(--ctp-mocha-overlay1) !important;
 }
 
+.note-list-item:hover {
+  background-color: var(--ctp-mocha-overlay0) !important;
+}
+
 .item-list.note-list .list-item-container::before {
+  border: none !important;
+}
+
+.note-list-item::before{
   border: none !important;
 }
 
@@ -287,11 +295,22 @@ div[height="50"] button span {
 
 .note-list .list-item-container a:focus {
   color: var(--ctp-mocha-text) !important;
+}
+
+.list-item-wrapper.-selected {
   background-color: var(--ctp-mocha-base) !important;
+}
+
+.note-list-item > .content.-selected {
+  background-color: var(--ctp-mocha-surface2) !important;
 }
 
 .note-list .list-item-container a:hover {
   color: var(--ctp-mocha-text) !important;
+}
+
+.list-item-wrapper.-highlight-on-hover:hover {
+  background-color: var(--ctp-mocha-surface1);
 }
 
 /* Add "..." to notes with long titles */


### PR DESCRIPTION
Before | After
--- | ---
![image](https://github.com/user-attachments/assets/727d3cc5-1887-4373-8937-e9a3f2272752) | ![image](https://github.com/user-attachments/assets/006f6805-6239-4374-b44b-d37e0c73a365)


This PR updates all four Catppuccin themes to work with the newest version of Joplin.

Specifically:

* Added the missing cm-editor background color. The markdown editor before was using the default Joplin theme's background.
* Added missing classes for theming the note item panels on the left. Highlighted and selected colors previously used the default Joplin theme colors.

It's possible there's some old CSS that does nothing now because I assume this was themed in the past, but class names changed over time. Who cares though, what matters is that it looks good now and I can finally stop debugging front-ends.