### PR TITLE
Fix install instruction on Linux and text color to light theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 1. Download the files `userchrome.css` and `userstyle.css` from your preferred flavour from the `src/` directory.
 2. Move these files to the Joplin configuration directory:\
-   Linux/macOS: `~/.config/joplin/`\
+   Linux/macOS: `~/.config/joplin-desktop/`\
    Windows: `C:\Users\%USERNAME%\.config\joplin\`
 3. You need the [Rich Markdown Plugin](https://github.com/CalebJohn/joplin-rich-markdown) and need to enable extra CSS options by going into `Options -> Rich Markdown -> Add additional CSS classes for enhanced customization`.
 4. Enable the dark theme from Appearance to use the theme. 

--- a/src/latte/userchrome.css
+++ b/src/latte/userchrome.css
@@ -44,6 +44,7 @@
 /* Font used by Joplin */
 * {
   font-family: var(--font-face) !important;
+  color: var(--ctp-latte-text) !important;
 }
 
 html, body {
@@ -266,6 +267,9 @@ div[height="50"] button span {
 .new-note-todo-buttons > button {
   background-color: var(--ctp-latte-lavender) !important;
   border: none !important;
+}
+.new-note-button > span {
+  color: var(--ctp-latte-mantle) !important;
 }
 .new-todo-button > span {
   color: var(--ctp-latte-mantle) !important;


### PR DESCRIPTION
Linux installation path is wrong, so `README.md` was updated accordingly.

Latte theme text in unreadable in `SIDEBAR` (light text colour over light background) also fixed.